### PR TITLE
fix(input-number): fix render default arrow caused by form-item attrs contain type and not effect when modelValue is 0

### DIFF
--- a/packages/web-vue/components/input-number/input-number.tsx
+++ b/packages/web-vue/components/input-number/input-number.tsx
@@ -363,6 +363,7 @@ export default defineComponent({
           onFocus={handleFocus}
           onBlur={handleBlur}
           {...attrs}
+          type="text"
         />
       );
     };

--- a/packages/web-vue/components/input-number/input-number.tsx
+++ b/packages/web-vue/components/input-number/input-number.tsx
@@ -139,10 +139,10 @@ export default defineComponent({
     const prefixCls = getPrefixCls('input-number');
     const inputRef = ref<HTMLInputElement>();
     const _value = ref(
-      props.defaultValue
-        ? props.formatter?.(String(props.defaultValue)) ??
-            String(props.defaultValue)
-        : ''
+      isUndefined(props.defaultValue)
+        ? ''
+        : props.formatter?.(String(props.defaultValue)) ??
+        String(props.defaultValue)
     );
     const mergedPrecision = computed(() => {
       if (isNumber(props.precision)) {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->

- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->
### form-item包含type属性时导致出现默认箭头
- 系统：MacOS 11.4
- 浏览器：Google Chrome 95.0.4638.54（正式版本） (arm64)
#### 描述
二次封装动态渲染表单时，使用如下操作
```vue
<a-form-item
          :field="column.prop"
          :label="column.name"
          v-bind="column"
        >
          <a-input
            v-if="!column.type || column.type === 'text'"
            v-model="form[column.prop]"
            type="number"
          />
          <a-input-number
            v-if="column.type === 'number'"
            v-model="form[column.prop]"
            v-bind="column"
            type="text"
          />
</a-form-item>
```
此时当column包含{type:'number'}，由于a-form-item将attrs传递给children
![image](https://user-images.githubusercontent.com/93666053/140264272-40a7a1a1-0a7e-448f-a065-cfb9ad8e0871.png)
将会导致a-input-number出现双上下箭头
![image](https://user-images.githubusercontent.com/93666053/140252851-d5d8c7c7-94f0-41da-9edf-618a30e3e5a2.png)

### v-model绑定对象初始为0时不生效
```ts
const value = ref(0)
```
```vue
<a-input-number v-model="value" />
```

## Solution

<!-- Describe how the problem is fixed in detail -->
- 将a-input-number中引用a-input的type指定为text，避免被attrs影响
- 初始时判断props.modeValue为undefined时才赋值_value为空字符串

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   input  |  修复 `a-input-number` 组件 `model-value` 默认值为 0 时不生效的问题 | Fix the issue that the `a-input-number` component `model-value` does not take effect when the default value is 0  |                |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
