### PR TITLE
Add a slot named error-icon to support custom error status icon

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,5 @@
 {
-  "eslint.workingDirectories": [
-    { "directory": "packages/web-vue", "changeProcessCWD": true },
-    { "directory": "packages/vue-site", "changeProcessCWD": true },
-    { "directory": "packages/vite-plugin-vue-md", "changeProcessCWD": true },
-    { "directory": "packages/arco-vue-site-nav", "changeProcessCWD": true },
-    { "directory": "packages/arco-vue-scripts", "changeProcessCWD": true }
-  ]
+  "eslint.workingDirectories": [{
+    "pattern": "./packages/*/"
+  }]
 }

--- a/packages/web-vue/components/image/README.en-US.md
+++ b/packages/web-vue/components/image/README.en-US.md
@@ -53,6 +53,13 @@ description: Used to show and preview pictures.
 |Event Name|Description|Parameters|
 |---|---|---|
 |preview-visible-change|Preview opening and closing events|visible: `boolean`|
+### `<image>` Slots
+
+|Slot Name|Description|Parameters|
+|---|---|---|
+|error|Customize error content.|-|
+|error-icon|Customize the icon of error content.|-|
+|loader|Customize loading effect.|-|
 
 
 

--- a/packages/web-vue/components/image/README.zh-CN.md
+++ b/packages/web-vue/components/image/README.zh-CN.md
@@ -51,6 +51,13 @@ description: 展示和预览图片。
 |事件名|描述|参数|
 |---|---|---|
 |preview-visible-change|预览的打开和关闭事件|visible: `boolean`|
+### `<image>` Slots
+
+|插槽名|描述|参数|
+|---|:---:|---|
+|error|自定义错误状态内容|-|
+|error-icon|自定义错误状态的图标|-|
+|loader|自定义加载状态效果|-|
 
 
 

--- a/packages/web-vue/components/image/image.vue
+++ b/packages/web-vue/components/image/image.vue
@@ -13,7 +13,9 @@
       <slot v-if="isError" name="error">
         <div :class="`${prefixCls}-error`">
           <div :class="`${prefixCls}-error-icon`">
-            <IconImageClose />
+            <slot name="error-icon">
+              <IconImageClose />
+            </slot>
           </div>
           <div :class="`${prefixCls}-error-alt`">{{ alt || description }}</div>
         </div>
@@ -197,6 +199,21 @@ export default defineComponent({
     'preview-visible-change',
     'update:previewVisible',
   ],
+  /**
+   * @zh 自定义错误状态的图标
+   * @en Customize the icon of error content.
+   * @slot error-icon
+   */
+  /**
+   * @zh 自定义错误状态内容
+   * @en Customize error content.
+   * @slot error
+   */
+  /**
+   * @zh 自定义加载状态效果
+   * @en Customize loading effect.
+   * @slot loader
+   */
   setup(props: ImageProps, { attrs, slots, emit }) {
     const { t } = useI18n();
     const {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->

- [x] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

add a slot named error-icon to support custom error status icon

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|image| 增加一个名为 `error-icon` 的 slot 用于支持定制错误状态的图标|Add a slot named error-icon to support custom error status icon| #51|

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
