### PR TITLE
fix: right-clicking does not release the drag event

### DIFF
--- a/packages/web-vue/components/slider/slider-button.vue
+++ b/packages/web-vue/components/slider/slider-button.vue
@@ -48,13 +48,17 @@ export default defineComponent({
     const prefixCls = getPrefixCls('slider-btn');
     const isDragging = ref(false);
 
-    const handleMouseDown = () => {
+    const handleMouseDown = (e: MouseEvent) => {
       if (props.disabled) {
         return;
       }
+
+      e.preventDefault();
+
       isDragging.value = true;
       on(window, 'mousemove', handleMouseMove);
       on(window, 'mouseup', handleMouseUp);
+      on(window, 'contextmenu', handleMouseUp);
       emit('movestart');
     };
 


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->

- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

1. Release the drag event when right-click.
2. Prevent the default behavior of mousedown.

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|       slider    |   修复点击右键没有释放拖拽事件的问题           |    Fixed the problem that the right click did not release the drag event           |        Close #73         |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
