### PR TITLE
fix(virtual-list): reset itemRenderCache when internalData changes

### DIFF
--- a/packages/web-vue/components/_components/virtual-list/hooks/use-render-children.tsx
+++ b/packages/web-vue/components/_components/virtual-list/hooks/use-render-children.tsx
@@ -2,11 +2,12 @@ import { toRefs, VNode, cloneVNode, watch } from 'vue';
 import { ItemSlot, InternalDataItem } from '../interface';
 
 export function useRenderChildren(props: {
+  internalData: InternalDataItem[];
   visibleData: InternalDataItem[];
   itemRef: (el: HTMLElement, key: string) => void;
   itemRender: ItemSlot;
 }) {
-  const { visibleData, itemRender, itemRef } = toRefs(props);
+  const { internalData, visibleData, itemRender, itemRef } = toRefs(props);
   let itemRenderCache: { [index: number]: VNode } = {};
 
   const internalItemRender = (item: unknown, index: number) => {
@@ -44,7 +45,7 @@ export function useRenderChildren(props: {
     return children;
   };
 
-  watch(itemRender, () => {
+  watch([internalData, itemRender], () => {
     itemRenderCache = {};
   });
 

--- a/packages/web-vue/components/_components/virtual-list/virtual-list.vue
+++ b/packages/web-vue/components/_components/virtual-list/virtual-list.vue
@@ -213,6 +213,7 @@ export default defineComponent({
     const itemRender = usePickSlots(slots, 'item') as Ref<ItemSlot>;
     const renderChildren = useRenderChildren(
       reactive({
+        internalData,
         visibleData,
         itemRender,
         itemRef: (el: HTMLElement | null, key: string) => {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->

- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

Fixes #61 

In `packages/web-vue/components/_components/virtual-list/hooks/use-render-children.tsx`, VNode will be cached by index on render.

When virtual list data prop changes, the index of each virtual list item may change but the cache is not reset. And the wrong VNode from the cache will be used to render new item.

In #61 , when expand/collapse a tree node, the `data` prop passed to virtual list component changes. But the cached VNodes are used to render new tree nodes and it looks like the parent node cannot be collapsed.

![image](https://user-images.githubusercontent.com/9395932/141174115-55b4b811-f505-4184-ac13-a539d5d8571f.png)

Attention to node `0-0-0-5`, the next sibling node should be `0-0-0-6` if its parent node is expanded.

## Solution

<!-- Describe how the problem is fixed in detail -->

Pass `internalData` to `useRenderChildren` hook and reset `itemRenderCache` when `internalData` changes.

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| virtual-list          | 当虚拟列表 data prop 改变时重置 VNode 缓存              | Reset VNode cache when virtual list data prop changes              | Close #61                |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
