### PR TITLE
fix(page-header): fix dividing will also be displayed when there is no subtitle

### DIFF
--- a/packages/web-vue/components/page-header/page-header.vue
+++ b/packages/web-vue/components/page-header/page-header.vue
@@ -16,8 +16,14 @@
           <span :class="`${prefixCls}-title`">
             <slot name="title">{{ title }}</slot>
           </span>
-          <span :class="`${prefixCls}-divider`" />
-          <span :class="`${prefixCls}-subtitle`">
+          <span
+            v-if="$slots.subtitle || subtitle"
+            :class="`${prefixCls}-divider`"
+          />
+          <span
+            v-if="$slots.subtitle || subtitle"
+            :class="`${prefixCls}-subtitle`"
+          >
             <slot name="subtitle">{{ subtitle }}</slot>
           </span>
         </span>


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->

- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

Fix dividing will also be displayed when there is no subtitle

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| page-header | 修复没有子标题时仍然显示分割线的问题  | Fix the problem that the dividing line is still displayed when there is no subtitle | Close #218  |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
