### PR TITLE
fix(tree-select): fix the problem that filter is invalid when rename the key field

### DIFF
--- a/packages/web-vue/components/tree-select/__demo__/basic.md
+++ b/packages/web-vue/components/tree-select/__demo__/basic.md
@@ -22,7 +22,7 @@ Basic usage example.
     :data="treeData"
     placeholder="Please select ..."
     style="width: 300px"
-  />
+  ></a-tree-select>
 </template>
 <script>
   import { h } from 'vue';

--- a/packages/web-vue/components/tree-select/__demo__/checkable.md
+++ b/packages/web-vue/components/tree-select/__demo__/checkable.md
@@ -37,7 +37,7 @@ The `treeCheckable` property can display checkbox.
     :data="treeData"
     placeholder="Please select ..."
     style="width: 300px;"
-  />
+  ></a-tree-select>
 </template>
 <script>
   import { ref } from 'vue';

--- a/packages/web-vue/components/tree-select/__demo__/checked-strategy.md
+++ b/packages/web-vue/components/tree-select/__demo__/checked-strategy.md
@@ -45,7 +45,7 @@ Customize the return value through the `treeCheckStrategy` property.
     :data="treeData"
     placeholder="Please select ..."
     style="width: 300px;"
-  />
+  ></a-tree-select>
 </template>
 <script>
   import { ref } from 'vue';

--- a/packages/web-vue/components/tree-select/__demo__/control.md
+++ b/packages/web-vue/components/tree-select/__demo__/control.md
@@ -23,7 +23,7 @@ The selected value supports two-way binding.
     v-model="selected"
     placeholder="Please select ..."
     style="width: 300px"
-  />
+  ></a-tree-select>
 </template>
 <script>
   import { h, ref } from 'vue';

--- a/packages/web-vue/components/tree-select/__demo__/field-names.md
+++ b/packages/web-vue/components/tree-select/__demo__/field-names.md
@@ -28,7 +28,7 @@ You can customize `treeData` by `fieldNames`.
     :data="treeData"
     placeholder="Please select ..."
     style="width: 300px;"
-  />
+  ></a-tree-select>
 </template>
 <script>
   export default {

--- a/packages/web-vue/components/tree-select/__demo__/label-in-value.md
+++ b/packages/web-vue/components/tree-select/__demo__/label-in-value.md
@@ -25,7 +25,7 @@ When `labelInValue` is `true`, the format of `value` is: `{ label: string, value
     placeholder="Please select ..."
     style="width: 300px"
     @change="onChange"
-  />
+  ></a-tree-select>
 </template>
 <script>
   import { h } from 'vue';

--- a/packages/web-vue/components/tree-select/__demo__/load-more.md
+++ b/packages/web-vue/components/tree-select/__demo__/load-more.md
@@ -23,7 +23,7 @@ Load nodes dynamically via `loadMore`. At this time, `isLeaf` can be set to indi
     :load-more="loadMore"
     placeholder="Please select ..."
     style="width: 300px"
-  />
+  ></a-tree-select>
 </template>
 <script>
   import { ref } from 'vue';

--- a/packages/web-vue/components/tree-select/__demo__/multiple.md
+++ b/packages/web-vue/components/tree-select/__demo__/multiple.md
@@ -27,7 +27,7 @@ Multiple Selection
       :data="treeData"
       placeholder="Please select ..."
       style="width: 300px"
-    />
+    ></a-tree-select>
     <a-tree-select
       v-model="selected"
       :multiple="true"
@@ -37,7 +37,7 @@ Multiple Selection
       :data="treeData"
       placeholder="Please select ..."
       style="width: 300px"
-    />
+    ></a-tree-select>
   </a-space>
 </template>
 <script>

--- a/packages/web-vue/components/tree-select/__demo__/popup-visible.md
+++ b/packages/web-vue/components/tree-select/__demo__/popup-visible.md
@@ -29,7 +29,7 @@ For example, in this demo, onVisibleChange is triggered when the mouse moves out
     :data="treeData"
     placeholder="Please select ..."
     style="width: 300px"
-  />
+  ></a-tree-select>
 </template>
 <script>
   import { ref } from 'vue';

--- a/packages/web-vue/components/tree-select/__demo__/search-remote.md
+++ b/packages/web-vue/components/tree-select/__demo__/search-remote.md
@@ -27,7 +27,7 @@ Listen to the `search` event, get the data in the event processing function and 
     style="width: 300px"
     placeholder="Please select ..."
     @search="onSearch"
-  />
+  ></a-tree-select>
 </template>
 <script>
   import { ref } from 'vue';

--- a/packages/web-vue/components/tree-select/__demo__/search.md
+++ b/packages/web-vue/components/tree-select/__demo__/search.md
@@ -25,7 +25,7 @@ Set `:allow-search="true"` to enable the search function. You can only search in
       :data="treeData"
       placeholder="Please select ..."
       style="width: 300px"
-    />
+    ></a-tree-select>
     <a-tree-select
       :allow-search="true"
       :allow-clear="true"
@@ -33,7 +33,7 @@ Set `:allow-search="true"` to enable the search function. You can only search in
       :filter-tree-node="filterTreeNode"
       placeholder="Please select ..."
       style="width: 300px"
-    />
+    ></a-tree-select>
   </a-space>
 </template>
 <script>

--- a/packages/web-vue/components/tree-select/__demo__/size.md
+++ b/packages/web-vue/components/tree-select/__demo__/size.md
@@ -32,7 +32,7 @@ Four sizes (small, default, large, huge) can be selected through `size`. The hei
     :data="treeData"
     placeholder="Please select ..."
     style="width: 300px;"
-  />
+  ></a-tree-select>
 </template>
 <script>
   import { ref } from 'vue';

--- a/packages/web-vue/components/tree-select/__demo__/virtual.md
+++ b/packages/web-vue/components/tree-select/__demo__/virtual.md
@@ -23,7 +23,7 @@ By specifying `treeProps.virtualListProps` to turn on the virtual list, high per
         height: 200
       },
     }"
-  />
+  ></a-tree-select>
 </template>
 <script>
   export default {

--- a/packages/web-vue/components/tree-select/tree-select.vue
+++ b/packages/web-vue/components/tree-select/tree-select.vue
@@ -85,7 +85,7 @@ import {
   StyleValue,
 } from 'vue';
 import useMergeState from '../_hooks/use-merge-state';
-import { LabelValue, TreeSelectProps } from './interface';
+import { LabelValue } from './interface';
 import Trigger from '../trigger';
 import SelectView from '../_components/select-view/select-view';
 import Panel from './panel';
@@ -504,6 +504,7 @@ export default defineComponent({
           flattenTreeData,
           filterMethod: filterTreeNode,
           disableFilter,
+          fieldNames,
         })
       );
 


### PR DESCRIPTION
fix the problem that filter is invalid when rename the key field

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->

- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|     tree-select      |   修复设置 key 字段名的时候搜索失效的问题            |      fix the problem that search is invalid when rename the key field         |     Close #387           |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
