### PR TITLE
perf(table): button not trigger row-click

### DIFF
--- a/packages/web-vue/components/table/table-operation-td.tsx
+++ b/packages/web-vue/components/table/table-operation-td.tsx
@@ -86,6 +86,7 @@ export default defineComponent({
             disabled={Boolean(props.record.disabled)}
             uninjectGroupContext
             onChange={(value: string) => emit('select', [value])}
+            onClick={(ev: Event) => ev.stopPropagation()}
           />
         );
       }
@@ -97,6 +98,7 @@ export default defineComponent({
           disabled={Boolean(props.record.disabled)}
           uninjectGroupContext
           onChange={(values: string[]) => emit('select', values)}
+          onClick={(ev: Event) => ev.stopPropagation()}
         />
       );
     };

--- a/packages/web-vue/components/table/table.tsx
+++ b/packages/web-vue/components/table/table.tsx
@@ -1098,7 +1098,10 @@ export default defineComponent({
         <button
           type="button"
           class={`${prefixCls}-expand-btn`}
-          onClick={(ev: Event) => handleExpand(currentKey)}
+          onClick={(ev: Event) => {
+            handleExpand(currentKey);
+            ev.stopPropagation();
+          }}
         >
           {slots['expand-icon']?.({ expanded, record }) ??
             props.expandable?.icon?.(expanded, record) ??


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [x] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others

## Background and context

button not trigger row-click

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  table  |   内部按钮不再触发 `row-click` 事件   |  Internal buttons no longer fire `row-click` events  |                |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
