### PR TITLE
perf(list): always render spin; support any child element

### DIFF
--- a/packages/web-vue/components/_utils/vue-utils.ts
+++ b/packages/web-vue/components/_utils/vue-utils.ts
@@ -333,15 +333,24 @@ export const getRenderFunc = (content: RenderContent) => {
   return () => content;
 };
 
-export const getAllElements = (vns: VNode[] | undefined) => {
+export const getAllElements = (
+  children: VNode[] | undefined,
+  includeText = false
+) => {
   const results: VNode[] = [];
-  for (const vn of vns ?? []) {
-    if (isElement(vn) || isComponent(vn) || isTextChildren(vn, vn.children)) {
-      results.push(vn);
-    } else if (isArrayChildren(vn, vn.children)) {
-      results.push(...getAllElements(vn.children));
-    } else if (isSlotsChildren(vn, vn.children)) {
-      results.push(...getAllElements(vn.children.default?.()));
+  for (const item of children ?? []) {
+    if (
+      isElement(item) ||
+      isComponent(item) ||
+      (includeText && isTextChildren(item, item.children))
+    ) {
+      results.push(item);
+    } else if (isArrayChildren(item, item.children)) {
+      results.push(...getAllElements(item.children, includeText));
+    } else if (isSlotsChildren(item, item.children)) {
+      results.push(...getAllElements(item.children.default?.(), includeText));
+    } else if (isArray(item)) {
+      results.push(...getAllElements(item, includeText));
     }
   }
   return results;
@@ -405,7 +414,10 @@ export const getFirstElement = (vn: VNode | VNode[]): HTMLElement | null => {
       const result = getFirstElement(child);
       if (result) return result;
     }
-  } else if (isComponent(vn) && (vn.el as Node)?.nodeType === 1) {
+  } else if (
+    (isElement(vn) || isComponent(vn)) &&
+    (vn.el as Node)?.nodeType === 1
+  ) {
     return vn.el as HTMLElement;
   } else if (isArrayChildren(vn, vn.children)) {
     for (const child of vn.children) {

--- a/packages/web-vue/components/space/space.tsx
+++ b/packages/web-vue/components/space/space.tsx
@@ -116,7 +116,7 @@ export default defineComponent({
     };
 
     return () => {
-      const children = getAllElements(slots.default?.()).filter(
+      const children = getAllElements(slots.default?.(), true).filter(
         (item) => item.type !== Comment
       );
 


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [x] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  list  |   默认渲染 spin 组件，防止切换状态时导致组件重新挂载   |   The spin component is rendered by default to prevent the component from remounting when switching states   |                |
|  list  |   支持渲染任何子元素   |   Supports rendering of any child element  |                |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
