### PR TITLE
perf(form): nowrap when auto-label-width

### DIFF
--- a/packages/web-vue/components/form/form.vue
+++ b/packages/web-vue/components/form/form.vue
@@ -327,6 +327,9 @@ export default defineComponent({
       prefixCls,
       `${prefixCls}-layout-${props.layout}`,
       `${prefixCls}-size-${size.value}`,
+      {
+        [`${prefixCls}-auto-label-width`]: props.autoLabelWidth,
+      },
     ]);
 
     return {

--- a/packages/web-vue/components/form/style/index.less
+++ b/packages/web-vue/components/form/style/index.less
@@ -23,6 +23,12 @@
     margin-bottom: @form-inline-margin-item-bottom;
   }
 
+  &-auto-label-width &-item-label-col {
+    > label {
+      white-space: nowrap;
+    }
+  }
+
   &-item {
     display: flex;
     align-items: flex-start;


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [x] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   form   |   `auto-label-width` 开启时不在允许标签换行，防止换行后计算错误   |  When `auto-label-width` is enabled, label wrapping is not allowed to prevent calculation errors after wrapping  |                |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
