### PR TITLE
fix(virtual-list): visibleCount is now calculated from the minItemheight

### DIFF
--- a/packages/web-vue-storybook/stories/components/virtual-list.vue
+++ b/packages/web-vue-storybook/stories/components/virtual-list.vue
@@ -89,7 +89,7 @@ export default {
       new Array(10000).fill(null).map((_, index) => ({
         key: index,
         label: `label-${index}`,
-        height: Math.random() * 100 + 16,
+        height: Math.random() * 200 + 16,
         background: ['red', 'blue', 'yellow', 'green'][
           Math.floor(Math.random() * 4)
         ],

--- a/packages/web-vue/components/_components/virtual-list/hooks/use-item-height.ts
+++ b/packages/web-vue/components/_components/virtual-list/hooks/use-item-height.ts
@@ -32,6 +32,10 @@ export function useItemHeight(props: {
     () => estimatedItemHeight.value || DEFAULT_ITEM_HEIGHT
   );
 
+  const minItemHeight = computed(() =>
+    Math.min(...Object.values(itemHeightCacheMap.value), itemHeight.value)
+  );
+
   const totalHeight = computed(() =>
     data.value.reduce((sum, { key }) => sum + getItemHeightOrDefault(key), 0)
   );
@@ -59,6 +63,7 @@ export function useItemHeight(props: {
 
   return {
     itemHeight,
+    minItemHeight,
     estimatedItemHeight,
     totalHeight,
     setItemHeight,

--- a/packages/web-vue/components/_components/virtual-list/virtual-list.vue
+++ b/packages/web-vue/components/_components/virtual-list/virtual-list.vue
@@ -152,6 +152,7 @@ export default defineComponent({
 
     const {
       itemHeight,
+      minItemHeight,
       estimatedItemHeight,
       totalHeight,
       setItemHeight,
@@ -167,7 +168,7 @@ export default defineComponent({
 
     const itemCount = computed(() => data.value.length);
     const visibleCount = computed(() =>
-      Math.ceil(viewportHeight.value / itemHeight.value)
+      Math.ceil(viewportHeight.value / minItemHeight.value)
     );
 
     const scrollTop = ref(0);
@@ -363,11 +364,9 @@ export default defineComponent({
 
     return {
       viewportRef,
-      visibleData,
       viewportHeight,
       totalHeight,
       startOffset,
-      itemHeight,
       isVirtual,
       renderChildren,
       handleWrapperResize,


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->

- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    virtual-list       |     修复虚拟列表在项目高度偏差较大的时候出现底部空白的问题          |       Fixed the problem that the bottom blank of the virtual list appears when the item height deviation is large        |         close #758        |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
