### PR TITLE
fix(tree-select): the event change has wrong params when label-in-value is true

### DIFF
--- a/packages/web-vue/components/tree-select/hooks/use-selected-state.ts
+++ b/packages/web-vue/components/tree-select/hooks/use-selected-state.ts
@@ -145,5 +145,7 @@ export default function useSelectedState(props: {
     setLocalSelectedKeys(keys: TreeNodeKey[]) {
       localValueKeys.value = keys;
     },
+    localSelectedKeys: localValueKeys,
+    localSelectedValue: localValue,
   };
 }

--- a/packages/web-vue/components/tree-select/tree-select.vue
+++ b/packages/web-vue/components/tree-select/tree-select.vue
@@ -456,19 +456,24 @@ export default defineComponent({
       })
     );
 
-    const { selectedKeys, selectedValue, setLocalSelectedKeys } =
-      useSelectedState(
-        reactive({
-          defaultValue,
-          modelValue,
-          key2TreeNode,
-          multiple,
-          treeCheckable,
-          treeCheckStrictly,
-          fallbackOption,
-          fieldNames,
-        })
-      );
+    const {
+      selectedKeys,
+      selectedValue,
+      setLocalSelectedKeys,
+      localSelectedKeys,
+      localSelectedValue,
+    } = useSelectedState(
+      reactive({
+        defaultValue,
+        modelValue,
+        key2TreeNode,
+        multiple,
+        treeCheckable,
+        treeCheckStrictly,
+        fallbackOption,
+        fieldNames,
+      })
+    );
 
     const selectViewValue = computed(() => {
       if (isUndefined(selectedValue.value)) {
@@ -481,10 +486,12 @@ export default defineComponent({
       setLocalSelectedKeys(newVal);
 
       nextTick(() => {
-        let emitValue: TreeNodeKey | TreeNodeKey[] | LabelValue | LabelValue[] =
-          (labelInValue.value ? selectedValue.value : newVal) || [];
+        const forEmitValue =
+          (labelInValue.value
+            ? localSelectedValue.value
+            : localSelectedKeys.value) || [];
 
-        emitValue = isMultiple.value ? emitValue : emitValue[0];
+        const emitValue = isMultiple.value ? forEmitValue : forEmitValue[0];
 
         emit('update:modelValue', emitValue);
         emit('change', emitValue);


### PR DESCRIPTION
…ue is true

<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->

- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    tree-select       |       当 label-in-value 为 true 的时候，事件 change 的入参错误        |       When the prop label-in-value is true, the actual parameter value of the event change is wrong        |     close #940            |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
