### PR TITLE
feat(cascader): add object value support

### DIFF
--- a/packages/web-vue/components/_utils/types.ts
+++ b/packages/web-vue/components/_utils/types.ts
@@ -21,6 +21,7 @@ type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
   : never;
 
 export type BaseType = string | number;
+export type UnionType = BaseType | Record<string, any>;
 export type Data = Record<string, any>;
 export type RenderContent = string | RenderFunction;
 

--- a/packages/web-vue/components/cascader/README.en-US.md
+++ b/packages/web-vue/components/cascader/README.en-US.md
@@ -28,7 +28,11 @@ description: Refers to the use of multi-level classification to separate the opt
 
 @import ./__demo__/path.md
 
+@import ./__demo__/fallback.md
+
 @import ./__demo__/field-names.md
+
+@import ./__demo__/expand.md
 
 @import ./__demo__/panel.md
 
@@ -41,8 +45,8 @@ description: Refers to the use of multi-level classification to separate the opt
 |---|---|---|:---:|:---|
 |path-mode|Whether the value is a path|`boolean`|`false`||
 |multiple|Whether it is a multi-selection state (The search is turned on by default in the multi-select mode)|`boolean`|`false`||
-|model-value **(v-model)**|Value|`string \| number \| (string \| number \| (string \| number)[])[] \| undefined`|`-`||
-|default-value|Default value (uncontrolled state)|`string \| number \| (string \| number \| (string \| number)[])[] \| undefined`|`'' \| undefined \| []`||
+|model-value **(v-model)**|Value|`string\| number\| Record<string, any>\| (    \| string    \| number    \| Record<string, any>    \| (string \| number \| Record<string, any>)[]  )[]\| undefined`|`-`||
+|default-value|Default value (uncontrolled state)|`string\| number\| Record<string, any>\| (    \| string    \| number    \| Record<string, any>    \| (string \| number \| Record<string, any>)[]  )[]\| undefined`|`'' \| undefined \| []`||
 |options|Options for cascader|`CascaderOption[]`|`[]`||
 |disabled|Whether to disable|`boolean`|`false`||
 |error|Whether it is an error state|`boolean`|`false`||
@@ -52,19 +56,22 @@ description: Refers to the use of multi-level classification to separate the opt
 |input-value **(v-model)**|The value of the input|`string`|`-`||
 |default-input-value|The default value of the input (uncontrolled state)|`string`|`''`||
 |popup-visible **(v-model)**|Whether to show the dropdown|`boolean`|`-`||
-|expand-trigger|Expand the trigger method of the next level|`string`|`'click'`||
+|expand-trigger|Expand the trigger method of the next level|`'click' \| 'hover'`|`'click'`||
 |default-popup-visible|Whether to display the dropdown by default (uncontrolled state)|`boolean`|`false`||
 |placeholder|Placeholder|`string`|`-`||
 |popup-container|Mount container for popup|`string \| HTMLElement \| null \| undefined`|`-`||
 |max-tag-count|In multi-select mode, the maximum number of labels displayed. 0 means unlimited|`number`|`0`||
-|format-label|Format display content|`(options: CascaderOptionInfo[]) => string`|`-`||
+|format-label|Format display content|`(options: CascaderOption[]) => string`|`-`||
 |trigger-props|Trigger props of the drop-down menu|`TriggerProps`|`-`||
 |check-strictly|Whether to enable strict selection mode|`boolean`|`false`||
-|load-more|Data lazy loading function, open the lazy loading function when it is passed in|`(  option: CascaderOptionInfo,  done: (children?: CascaderOption[]) => void) => void`|`-`|2.13.0|
+|load-more|Data lazy loading function, open the lazy loading function when it is passed in|`(  option: CascaderOption,  done: (children?: CascaderOption[]) => void) => void`|`-`|2.13.0|
 |loading|Whether it is loading state|`boolean`|`false`|2.15.0|
 |search-option-only-label|Whether the options in the search dropdown show only label|`boolean`|`false`|2.18.0|
 |search-delay|Delay time to trigger search event|`number`|`500`|2.18.0|
 |field-names|Customize fields in `CascaderOption`|`CascaderFieldNames`|`-`|2.22.0|
+|value-key|Used to determine the option key value attribute name|`string`|`'value'`|2.29.0|
+|fallback|Options that do not exist in custom values|`boolean\| ((    value:      \| string      \| number      \| Record<string, unknown>      \| (string \| number \| Record<string, unknown>)[]  ) => string)`|`true`|2.29.0|
+|expand-child|whether to expand the submenu|`boolean`|`false`|2.29.0|
 ### `<cascader>` Events
 
 |Event Name|Description|Parameters|
@@ -97,13 +104,15 @@ description: Refers to the use of multi-level classification to separate the opt
 |---|---|---|:---:|:---|
 |path-mode|Whether the value is a path|`boolean`|`false`||
 |multiple|Whether it is a multi-selection state (The search is turned on by default in the multi-select mode)|`boolean`|`false`||
-|model-value **(v-model)**|Value|`string \| number \| (string \| number \| (string \| number)[])[] \| undefined`|`-`||
-|default-value|Default value (uncontrolled state)|`string \| number \| (string \| number \| (string \| number)[])[] \| undefined`|`'' \| undefined \| []`||
+|model-value **(v-model)**|Value|`string\| number\| Record<string, any>\| (    \| string    \| number    \| Record<string, any>    \| (string \| number \| Record<string, any>)[]  )[]\| undefined`|`-`||
+|default-value|Default value (uncontrolled state)|`string\| number\| Record<string, any>\| (    \| string    \| number    \| Record<string, any>    \| (string \| number \| Record<string, any>)[]  )[]\| undefined`|`'' \| undefined \| []`||
 |options|Options for cascader|`CascaderOption[]`|`[]`||
 |expand-trigger|Expand the trigger method of the next level|`string`|`'click'`||
 |check-strictly|Whether to enable strict selection mode|`boolean`|`false`||
-|load-more|Data lazy loading function, open the lazy loading function when it is passed in|`(  option: CascaderOptionInfo,  done: (children?: CascaderOption[]) => void) => void`|`-`|2.13.0|
+|load-more|Data lazy loading function, open the lazy loading function when it is passed in|`(  option: CascaderOption,  done: (children?: CascaderOption[]) => void) => void`|`-`|2.13.0|
 |field-names|Customize fields in `CascaderOption`|`CascaderFieldNames`|`-`|2.22.0|
+|value-key|Used to determine the option key value attribute name|`string`|`'value'`|2.29.0|
+|expand-child|whether to expand the submenu|`boolean`|`false`|2.29.0|
 ### `<cascader-panel>` Events
 
 |Event Name|Description|Parameters|

--- a/packages/web-vue/components/cascader/README.zh-CN.md
+++ b/packages/web-vue/components/cascader/README.zh-CN.md
@@ -26,7 +26,11 @@ description: 指在选择器选项数量较多时，采用多级分类的方式�
 
 @import ./__demo__/path.md
 
+@import ./__demo__/fallback.md
+
 @import ./__demo__/field-names.md
+
+@import ./__demo__/expand.md
 
 @import ./__demo__/panel.md
 
@@ -39,8 +43,8 @@ description: 指在选择器选项数量较多时，采用多级分类的方式�
 |---|---|---|:---:|:---|
 |path-mode|绑定值是否为路径|`boolean`|`false`||
 |multiple|是否为多选状态（多选模式默认开启搜索）|`boolean`|`false`||
-|model-value **(v-model)**|绑定值|`string \| number \| (string \| number \| (string \| number)[])[] \| undefined`|`-`||
-|default-value|默认值（非受控状态）|`string \| number \| (string \| number \| (string \| number)[])[] \| undefined`|`'' \| undefined \| []`||
+|model-value **(v-model)**|绑定值|`string\| number\| Record<string, any>\| (    \| string    \| number    \| Record<string, any>    \| (string \| number \| Record<string, any>)[]  )[]\| undefined`|`-`||
+|default-value|默认值（非受控状态）|`string\| number\| Record<string, any>\| (    \| string    \| number    \| Record<string, any>    \| (string \| number \| Record<string, any>)[]  )[]\| undefined`|`'' \| undefined \| []`||
 |options|级联选择器的选项|`CascaderOption[]`|`[]`||
 |disabled|是否禁用|`boolean`|`false`||
 |error|是否为错误状态|`boolean`|`false`||
@@ -50,19 +54,22 @@ description: 指在选择器选项数量较多时，采用多级分类的方式�
 |input-value **(v-model)**|输入框的值|`string`|`-`||
 |default-input-value|输入框的默认值（非受控状态）|`string`|`''`||
 |popup-visible **(v-model)**|是否显示下拉框|`boolean`|`-`||
-|expand-trigger|展开下一级的触发方式|`string`|`'click'`||
+|expand-trigger|展开下一级的触发方式|`'click' \| 'hover'`|`'click'`||
 |default-popup-visible|是否默认显示下拉框（非受控状态）|`boolean`|`false`||
 |placeholder|占位符|`string`|`-`||
 |popup-container|弹出框的挂载容器|`string \| HTMLElement \| null \| undefined`|`-`||
 |max-tag-count|多选模式下，最多显示的标签数量。0 表示不限制|`number`|`0`||
-|format-label|格式化展示内容|`(options: CascaderOptionInfo[]) => string`|`-`||
+|format-label|格式化展示内容|`(options: CascaderOption[]) => string`|`-`||
 |trigger-props|下拉菜单的触发器属性|`TriggerProps`|`-`||
 |check-strictly|是否开启严格选择模式|`boolean`|`false`||
-|load-more|数据懒加载函数，传入时开启懒加载功能|`(  option: CascaderOptionInfo,  done: (children?: CascaderOption[]) => void) => void`|`-`|2.13.0|
+|load-more|数据懒加载函数，传入时开启懒加载功能|`(  option: CascaderOption,  done: (children?: CascaderOption[]) => void) => void`|`-`|2.13.0|
 |loading|是否为加载中状态|`boolean`|`false`|2.15.0|
 |search-option-only-label|搜索下拉菜单中的选项是否仅展示标签|`boolean`|`false`|2.18.0|
 |search-delay|触发搜索事件的延迟时间|`number`|`500`|2.18.0|
 |field-names|自定义 `CascaderOption` 中的字段|`CascaderFieldNames`|`-`|2.22.0|
+|value-key|用于确定选项键值得属性名|`string`|`'value'`|2.29.0|
+|fallback|自定义不存在选项的值的展示|`boolean\| ((    value:      \| string      \| number      \| Record<string, unknown>      \| (string \| number \| Record<string, unknown>)[]  ) => string)`|`true`|2.29.0|
+|expand-child|是否展开子菜单|`boolean`|`false`|2.29.0|
 ### `<cascader>` Events
 
 |事件名|描述|参数|
@@ -95,13 +102,15 @@ description: 指在选择器选项数量较多时，采用多级分类的方式�
 |---|---|---|:---:|:---|
 |path-mode|绑定值是否为路径|`boolean`|`false`||
 |multiple|是否为多选状态（多选模式默认开启搜索）|`boolean`|`false`||
-|model-value **(v-model)**|绑定值|`string \| number \| (string \| number \| (string \| number)[])[] \| undefined`|`-`||
-|default-value|默认值（非受控状态）|`string \| number \| (string \| number \| (string \| number)[])[] \| undefined`|`'' \| undefined \| []`||
+|model-value **(v-model)**|绑定值|`string\| number\| Record<string, any>\| (    \| string    \| number    \| Record<string, any>    \| (string \| number \| Record<string, any>)[]  )[]\| undefined`|`-`||
+|default-value|默认值（非受控状态）|`string\| number\| Record<string, any>\| (    \| string    \| number    \| Record<string, any>    \| (string \| number \| Record<string, any>)[]  )[]\| undefined`|`'' \| undefined \| []`||
 |options|级联选择器的选项|`CascaderOption[]`|`[]`||
 |expand-trigger|展开下一级的触发方式|`string`|`'click'`||
 |check-strictly|是否开启严格选择模式|`boolean`|`false`||
-|load-more|数据懒加载函数，传入时开启懒加载功能|`(  option: CascaderOptionInfo,  done: (children?: CascaderOption[]) => void) => void`|`-`|2.13.0|
+|load-more|数据懒加载函数，传入时开启懒加载功能|`(  option: CascaderOption,  done: (children?: CascaderOption[]) => void) => void`|`-`|2.13.0|
 |field-names|自定义 `CascaderOption` 中的字段|`CascaderFieldNames`|`-`|2.22.0|
+|value-key|用于确定选项键值得属性名|`string`|`'value'`|2.29.0|
+|expand-child|是否展开子菜单|`boolean`|`false`|2.29.0|
 ### `<cascader-panel>` Events
 
 |事件名|描述|参数|

--- a/packages/web-vue/components/cascader/TEMPLATE.md
+++ b/packages/web-vue/components/cascader/TEMPLATE.md
@@ -37,7 +37,11 @@ description: Refers to the use of multi-level classification to separate the opt
 
 @import ./__demo__/path.md
 
+@import ./__demo__/fallback.md
+
 @import ./__demo__/field-names.md
+
+@import ./__demo__/expand.md
 
 @import ./__demo__/panel.md
 

--- a/packages/web-vue/components/cascader/__demo__/expand.md
+++ b/packages/web-vue/components/cascader/__demo__/expand.md
@@ -1,34 +1,29 @@
 ```yaml
 title:
-  zh-CN: 允许清除
-  en-US: Allow Clear
+  zh-CN: 展开子菜单
+  en-US: Expand child menu
 ```
 
 ## zh-CN
 
-允许清除。
+通过设置 `expand-child` 可以在选择时展开第一个子菜单
 
 ---
 
 ## en-US
 
-Allow clear.
+The first submenu can be expanded on selection by setting `expand-child`
 
 ---
 
 ```vue
 <template>
-  <a-cascader :options="options" v-model="value" :style="{width:'320px'}" placeholder="Please select ..."
-              allow-clear />
+  <a-cascader :options="options" :style="{width:'320px'}" placeholder="Please select ..." expand-child/>
 </template>
 
 <script>
-import { ref } from 'vue';
-
 export default {
   setup() {
-    const value = ref('datunli');
-
     const options = [
       {
         value: 'beijing',
@@ -80,7 +75,6 @@ export default {
       },
     ];
     return {
-      value,
       options
     }
   },

--- a/packages/web-vue/components/cascader/__demo__/fallback.md
+++ b/packages/web-vue/components/cascader/__demo__/fallback.md
@@ -1,25 +1,28 @@
 ```yaml
 title:
-  zh-CN: 允许清除
-  en-US: Allow Clear
+  zh-CN: 回退选项
+  en-US: Fallback
 ```
 
 ## zh-CN
 
-允许清除。
+组件默认会展示在选项中不存在的值，可通过 `fallback` 自定义展示或者关闭
 
 ---
 
 ## en-US
 
-Allow clear.
+The component will display the value that does not exist in the options by default, which can be displayed or turned off through `fallback`
 
 ---
 
 ```vue
 <template>
-  <a-cascader :options="options" v-model="value" :style="{width:'320px'}" placeholder="Please select ..."
-              allow-clear />
+  <a-space direction="vertical" size="large">
+    <a-cascader :options="options" v-model="value" :style="{width:'320px'}" placeholder="Please select ..." multiple />
+    <a-cascader :options="options" v-model="value2" :style="{width:'320px'}"
+                placeholder="Please select ..." path-mode multiple :fallback="fallback" />
+  </a-space>
 </template>
 
 <script>
@@ -27,7 +30,11 @@ import { ref } from 'vue';
 
 export default {
   setup() {
-    const value = ref('datunli');
+    const value = ref(['datunli', 'wuhou']);
+    const value2 = ref([['beijing', 'chaoyang', 'datunli'], ['sichuan', 'chengdu', 'wuhou']]);
+    const fallback = (value) => {
+      return value.map(item => item.toUpperCase()).join('-')
+    }
 
     const options = [
       {
@@ -80,8 +87,10 @@ export default {
       },
     ];
     return {
+      options,
       value,
-      options
+      value2,
+      fallback
     }
   },
 }

--- a/packages/web-vue/components/cascader/__demo__/panel.md
+++ b/packages/web-vue/components/cascader/__demo__/panel.md
@@ -18,7 +18,7 @@ Cascading menu can be used alone, in this case it is the `data display` componen
 
 ```vue
 <template>
-  <a-cascader-panel :options="options" v-model="value" />
+  <a-cascader-panel :options="options" v-model="value" expand-child/>
 </template>
 
 <script>

--- a/packages/web-vue/components/cascader/__test__/__snapshots__/demo.test.ts.snap
+++ b/packages/web-vue/components/cascader/__test__/__snapshots__/demo.test.ts.snap
@@ -44,6 +44,39 @@ exports[`<cascader> demo: render [disabled] correctly 1`] = `
 <!---->"
 `;
 
+exports[`<cascader> demo: render [expand] correctly 1`] = `
+"<span class=\\"arco-select-view-single arco-select-view arco-select-view-size-medium\\" style=\\"width: 320px;\\"><!----><input class=\\"arco-select-view-input\\" readonly=\\"\\" placeholder=\\"Please select ...\\"><span class=\\"arco-select-view-value arco-select-view-value-hidden\\"><!----></span><span class=\\"arco-select-view-suffix\\"><!----><span class=\\"arco-select-view-icon\\"><svg viewBox=\\"0 0 48 48\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\" stroke=\\"currentColor\\" class=\\"arco-icon arco-icon-down arco-select-view-arrow-icon\\" stroke-width=\\"4\\" stroke-linecap=\\"butt\\" stroke-linejoin=\\"miter\\"><path d=\\"M39.6 17.443 24.043 33 8.487 17.443\\"></path></svg></span>
+<!----></span></span>
+<!---->"
+`;
+
+exports[`<cascader> demo: render [fallback] correctly 1`] = `
+"<div class=\\"arco-space arco-space-vertical\\">
+  <div class=\\"arco-space-item\\" style=\\"margin-bottom: 24px;\\"><span class=\\"arco-select-view arco-select-view-size-medium arco-select-view-has-tag arco-select-view-has-suffix arco-select-view-multiple\\" style=\\"width: 320px;\\"><span class=\\"arco-select-view-mirror\\"></span>
+    <!---->
+    <transition-group-stub><span class=\\"arco-tag arco-tag-size-medium arco-tag-checked arco-select-view-tag\\"><!--v-if-->Beijing / ChaoYang / Datunli<span class=\\"arco-icon-hover arco-tag-icon-hover arco-tag-close-btn\\"><svg viewBox=\\"0 0 48 48\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\" stroke=\\"currentColor\\" class=\\"arco-icon arco-icon-close\\" stroke-width=\\"4\\" stroke-linecap=\\"butt\\" stroke-linejoin=\\"miter\\"><path d=\\"M9.857 9.858 24 24m0 0 14.142 14.142M24 24 38.142 9.858M24 24 9.857 38.142\\"></path></svg></span>
+      <!--v-if--></span><span class=\\"arco-tag arco-tag-size-medium arco-tag-checked arco-select-view-tag\\"><!--v-if-->wuhou<span class=\\"arco-icon-hover arco-tag-icon-hover arco-tag-close-btn\\"><svg viewBox=\\"0 0 48 48\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\" stroke=\\"currentColor\\" class=\\"arco-icon arco-icon-close\\" stroke-width=\\"4\\" stroke-linecap=\\"butt\\" stroke-linejoin=\\"miter\\"><path d=\\"M9.857 9.858 24 24m0 0 14.142 14.142M24 24 38.142 9.858M24 24 9.857 38.142\\"></path></svg></span>
+      <!--v-if--></span><input class=\\"arco-select-view-input\\" style=\\"width: 12px;\\">
+    </transition-group-stub>
+    <!----><span class=\\"arco-select-view-suffix\\"><!----><span class=\\"arco-select-view-icon\\"><svg viewBox=\\"0 0 48 48\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\" stroke=\\"currentColor\\" class=\\"arco-icon arco-icon-expand\\" style=\\"transform: rotate(-45deg);\\" stroke-width=\\"4\\" stroke-linecap=\\"butt\\" stroke-linejoin=\\"miter\\"><path d=\\"M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26\\"></path></svg></span>
+    <!---->
+    <!----></span></span>
+    <!---->
+  </div>
+  <div class=\\"arco-space-item\\"><span class=\\"arco-select-view arco-select-view-size-medium arco-select-view-has-tag arco-select-view-has-suffix arco-select-view-multiple\\" style=\\"width: 320px;\\"><span class=\\"arco-select-view-mirror\\"></span>
+    <!---->
+    <transition-group-stub><span class=\\"arco-tag arco-tag-size-medium arco-tag-checked arco-select-view-tag\\"><!--v-if-->Beijing / ChaoYang / Datunli<span class=\\"arco-icon-hover arco-tag-icon-hover arco-tag-close-btn\\"><svg viewBox=\\"0 0 48 48\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\" stroke=\\"currentColor\\" class=\\"arco-icon arco-icon-close\\" stroke-width=\\"4\\" stroke-linecap=\\"butt\\" stroke-linejoin=\\"miter\\"><path d=\\"M9.857 9.858 24 24m0 0 14.142 14.142M24 24 38.142 9.858M24 24 9.857 38.142\\"></path></svg></span>
+      <!--v-if--></span><span class=\\"arco-tag arco-tag-size-medium arco-tag-checked arco-select-view-tag\\"><!--v-if-->SICHUAN-CHENGDU-WUHOU<span class=\\"arco-icon-hover arco-tag-icon-hover arco-tag-close-btn\\"><svg viewBox=\\"0 0 48 48\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\" stroke=\\"currentColor\\" class=\\"arco-icon arco-icon-close\\" stroke-width=\\"4\\" stroke-linecap=\\"butt\\" stroke-linejoin=\\"miter\\"><path d=\\"M9.857 9.858 24 24m0 0 14.142 14.142M24 24 38.142 9.858M24 24 9.857 38.142\\"></path></svg></span>
+      <!--v-if--></span><input class=\\"arco-select-view-input\\" style=\\"width: 12px;\\">
+    </transition-group-stub>
+    <!----><span class=\\"arco-select-view-suffix\\"><!----><span class=\\"arco-select-view-icon\\"><svg viewBox=\\"0 0 48 48\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\" stroke=\\"currentColor\\" class=\\"arco-icon arco-icon-expand\\" style=\\"transform: rotate(-45deg);\\" stroke-width=\\"4\\" stroke-linecap=\\"butt\\" stroke-linejoin=\\"miter\\"><path d=\\"M7 26v14c0 .552.444 1 .996 1H22m19-19V8c0-.552-.444-1-.996-1H26\\"></path></svg></span>
+    <!---->
+    <!----></span></span>
+    <!---->
+  </div>
+</div>"
+`;
+
 exports[`<cascader> demo: render [field-names] correctly 1`] = `
 "<span class=\\"arco-select-view-single arco-select-view arco-select-view-size-medium\\" style=\\"width: 320px;\\"><!----><input class=\\"arco-select-view-input\\" readonly=\\"\\" placeholder=\\"Please select ...\\"><span class=\\"arco-select-view-value arco-select-view-value-hidden\\"><!----></span><span class=\\"arco-select-view-suffix\\"><!----><span class=\\"arco-select-view-icon\\"><svg viewBox=\\"0 0 48 48\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\" stroke=\\"currentColor\\" class=\\"arco-icon arco-icon-down arco-select-view-arrow-icon\\" stroke-width=\\"4\\" stroke-linecap=\\"butt\\" stroke-linejoin=\\"miter\\"><path d=\\"M39.6 17.443 24.043 33 8.487 17.443\\"></path></svg></span>
 <!----></span></span>

--- a/packages/web-vue/components/cascader/base-cascader-panel.tsx
+++ b/packages/web-vue/components/cascader/base-cascader-panel.tsx
@@ -17,15 +17,10 @@ export default defineComponent({
       required: true,
     },
     activeKey: String,
-    computedKeys: {
-      type: Array as PropType<string[]>,
-      required: true,
-    },
     totalLevel: {
       type: Number,
       required: true,
     },
-    expandTrigger: String,
     multiple: Boolean,
     checkStrictly: Boolean,
     loading: Boolean,
@@ -62,14 +57,12 @@ export default defineComponent({
                   <CascaderOption
                     key={item.key}
                     option={item}
-                    computedKeys={props.computedKeys}
                     active={
                       props.selectedPath.includes(item.key) ||
                       item.key === props.activeKey
                     }
                     multiple={props.multiple}
                     checkStrictly={props.checkStrictly}
-                    expandTrigger={props.expandTrigger}
                   />
                 );
               })}
@@ -109,6 +102,7 @@ export default defineComponent({
       <TransitionGroup
         tag="div"
         name="cascader-slide"
+        // @ts-ignore
         class={[
           `${prefixCls}-panel`,
           {

--- a/packages/web-vue/components/cascader/cascader-option.tsx
+++ b/packages/web-vue/components/cascader/cascader-option.tsx
@@ -8,7 +8,7 @@ import IconRight from '../icon/icon-right';
 import IconLoading from '../icon/icon-loading';
 import { getCheckedStatus, getOptionLabel } from './utils';
 import { isFunction } from '../_utils/is';
-import { cascaderInjectionKey } from './context';
+import { CascaderContext, cascaderInjectionKey } from './context';
 
 export default defineComponent({
   name: 'CascaderOption',
@@ -17,55 +17,56 @@ export default defineComponent({
       type: Object as PropType<CascaderOptionInfo>,
       required: true,
     },
-    computedKeys: {
-      type: Array as PropType<string[]>,
-      required: true,
-    },
     active: Boolean,
     multiple: Boolean,
-    expandTrigger: String,
     checkStrictly: Boolean,
     searchOption: Boolean,
     pathLabel: Boolean,
   },
   setup(props) {
     const prefixCls = getPrefixCls('cascader-option');
-    const cascaderCtx = inject(cascaderInjectionKey, undefined);
+    const cascaderCtx = inject<Partial<CascaderContext>>(
+      cascaderInjectionKey,
+      {}
+    );
 
     const isLoading = ref(false);
     const events: Record<string, any> = {};
 
     const handlePathChange = (ev: Event) => {
-      if (isFunction(cascaderCtx?.loadMore) && !props.option.isLeaf) {
+      if (isFunction(cascaderCtx.loadMore) && !props.option.isLeaf) {
         const { isLeaf, children, key } = props.option;
         if (!isLeaf && !children) {
           isLoading.value = true;
           new Promise<CascaderOption[] | undefined>((resolve) => {
-            cascaderCtx?.loadMore(props.option, resolve);
+            cascaderCtx.loadMore?.(props.option.raw, resolve);
           }).then((children?: CascaderOption[]) => {
             isLoading.value = false;
             if (children) {
-              cascaderCtx?.addLazyLoadOptions(children, key);
+              cascaderCtx.addLazyLoadOptions?.(children, key);
             }
           });
         }
       }
-      cascaderCtx?.setSelectedPath(props.option.key);
+      cascaderCtx.setSelectedPath?.(props.option.key);
     };
 
     if (!props.option.disabled) {
-      events.onMouseenter = [() => cascaderCtx?.setActiveKey(props.option.key)];
-      events.onMouseleave = () => cascaderCtx?.setActiveKey();
-
-      if (props.option.isLeaf && !props.multiple) {
-        events.onClick = (ev: Event) => {
-          handlePathChange(ev);
-          cascaderCtx?.onClickOption(props.option);
-        };
-      } else if (props.expandTrigger === 'hover') {
+      events.onMouseenter = [
+        () => cascaderCtx.setActiveKey?.(props.option.key),
+      ];
+      events.onMouseleave = () => cascaderCtx.setActiveKey?.();
+      events.onClick = [];
+      if (cascaderCtx.expandTrigger === 'hover') {
         events.onMouseenter.push((ev: Event) => handlePathChange(ev));
       } else {
-        events.onClick = (ev: Event) => handlePathChange(ev);
+        events.onClick.push((ev: Event) => handlePathChange(ev));
+      }
+      if (props.option.isLeaf && !props.multiple) {
+        events.onClick.push((ev: Event) => {
+          handlePathChange(ev);
+          cascaderCtx.onClickOption?.(props.option);
+        });
       }
     }
 
@@ -80,21 +81,22 @@ export default defineComponent({
     const checkedStatus = computed(() => {
       if (props.checkStrictly) {
         return {
-          checked: props.computedKeys.includes(props.option.key),
+          checked: cascaderCtx.valueMap?.has(props.option.key),
           indeterminate: false,
         };
       }
-      return getCheckedStatus(props.option, props.computedKeys);
+      return getCheckedStatus(props.option, cascaderCtx.valueMap);
     });
 
     const renderLabelContent = () => {
       if (props.pathLabel) {
         return (
-          cascaderCtx?.formatLabel?.(props.option.path) ??
-          getOptionLabel(props.option)
+          cascaderCtx?.formatLabel?.(
+            props.option.path.map((item) => item.raw)
+          ) ?? getOptionLabel(props.option)
         );
       }
-      if (cascaderCtx?.slots.option) {
+      if (cascaderCtx.slots?.option) {
         return cascaderCtx.slots.option({ data: props.option });
       }
       if (isFunction(props.option.render)) {
@@ -124,24 +126,26 @@ export default defineComponent({
             onChange={(value: any, ev: Event) => {
               ev.stopPropagation();
               handlePathChange(ev);
-              cascaderCtx?.onClickOption(
+              cascaderCtx.onClickOption?.(
                 props.option,
                 !checkedStatus.value.checked
               );
             }}
+            // @ts-ignore
             onClick={(ev: Event) => ev.stopPropagation()}
           />
         )}
         {props.checkStrictly && !props.multiple && (
           <Radio
-            modelValue={props.computedKeys.includes(props.option.key)}
+            modelValue={cascaderCtx.valueMap?.has(props.option.key)}
             disabled={props.option.disabled}
             uninjectGroupContext
             onChange={(value: any, ev: Event) => {
               ev.stopPropagation();
               handlePathChange(ev);
-              cascaderCtx?.onClickOption(props.option, true);
+              cascaderCtx.onClickOption?.(props.option, true);
             }}
+            // @ts-ignore
             onClick={(ev: Event) => ev.stopPropagation()}
           />
         )}

--- a/packages/web-vue/components/cascader/cascader-search-panel.tsx
+++ b/packages/web-vue/components/cascader/cascader-search-panel.tsx
@@ -12,10 +12,6 @@ export default defineComponent({
       type: Array as PropType<CascaderOptionInfo[]>,
       required: true,
     },
-    computedKeys: {
-      type: Array as PropType<string[]>,
-      required: true,
-    },
     loading: Boolean,
     activeKey: String,
     multiple: Boolean,
@@ -51,7 +47,6 @@ export default defineComponent({
               key={item.key}
               class={`${prefixCls}-search-option`}
               option={item}
-              computedKeys={props.computedKeys}
               active={item.key === props.activeKey}
               multiple={props.multiple}
               checkStrictly={props.checkStrictly}

--- a/packages/web-vue/components/cascader/context.ts
+++ b/packages/web-vue/components/cascader/context.ts
@@ -1,17 +1,20 @@
 import { InjectionKey, Slots } from 'vue';
 import { CascaderOption, CascaderOptionInfo } from './interface';
+import { UnionType } from '../_utils/types';
 
-interface CascaderContext {
+export interface CascaderContext {
   onClickOption: (option: CascaderOptionInfo, checked?: boolean) => void;
   setActiveKey: (key?: string) => void;
   setSelectedPath: (key?: string) => void;
   loadMore: (
-    option: CascaderOptionInfo,
+    option: CascaderOption,
     done: (children?: CascaderOption[]) => void
   ) => void;
   addLazyLoadOptions: (children: CascaderOption[], key: string) => void;
-  formatLabel: (options: CascaderOptionInfo[]) => string;
+  formatLabel: (options: CascaderOption[]) => string;
   slots: Slots;
+  valueMap: Map<string, UnionType | UnionType[]>;
+  expandTrigger: 'click' | 'hover';
 }
 
 export const cascaderInjectionKey: InjectionKey<CascaderContext> =

--- a/packages/web-vue/components/cascader/hooks/use-selected-path.ts
+++ b/packages/web-vue/components/cascader/hooks/use-selected-path.ts
@@ -7,10 +7,12 @@ export const useSelectedPath = (
     optionMap,
     filteredLeafOptions,
     showSearchPanel,
+    expandChild,
   }: {
     optionMap: Map<string, CascaderOptionInfo>;
     filteredLeafOptions: ComputedRef<CascaderOptionInfo[]>;
     showSearchPanel?: ComputedRef<boolean>;
+    expandChild: Ref<boolean>;
   }
 ) => {
   // active node key
@@ -35,7 +37,7 @@ export const useSelectedPath = (
   });
 
   const setSelectedPath = (key?: string) => {
-    const option = key ? optionMap.get(key) : undefined;
+    const option = getTargetOption(key);
     selectedPath.value = option?.path.map((item) => item.key) ?? [];
   };
 
@@ -54,6 +56,17 @@ export const useSelectedPath = (
     }
     return options.value.filter((item) => !item.disabled);
   });
+
+  const getTargetOption = (key?: string) => {
+    let target = key ? optionMap.get(key) : undefined;
+    if (expandChild.value) {
+      while (target && target.children && target.children.length > 0) {
+        // eslint-disable-next-line prefer-destructuring
+        target = target.children[0];
+      }
+    }
+    return target;
+  };
 
   const getNextActiveNode = (direction: 'next' | 'preview') => {
     const _length = enabledOptions.value?.length ?? 0;

--- a/packages/web-vue/components/cascader/interface.ts
+++ b/packages/web-vue/components/cascader/interface.ts
@@ -1,6 +1,11 @@
 import { RenderFunction } from 'vue';
 import { TagProps } from '../tag';
-import { FieldString } from '../_utils/types';
+import { BaseType, FieldString } from '../_utils/types';
+
+export type CascaderBaseValue =
+  | BaseType
+  | Record<string, any>
+  | (BaseType | Record<string, any>)[];
 
 export interface CascaderOption {
   /**
@@ -67,6 +72,7 @@ export interface CascaderNode extends CascaderOption {
 export interface CascaderOptionInfo extends CascaderOptionWithTotal {
   raw: Record<string, unknown>;
   key: string;
+  valueKey: string;
   level: number;
   index: number;
   value: string | number;
@@ -76,4 +82,5 @@ export interface CascaderOptionInfo extends CascaderOptionWithTotal {
   parent?: CascaderOptionInfo;
   children?: CascaderOptionInfo[];
   path: CascaderOptionInfo[];
+  pathValue: any[];
 }


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Type | Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | --------- | ------------- | ------------- | -------------- |
|  New feature  |  cascader  |    选项 value 支持对象格式，增加 `value-key` 属性    |    Option value supports object format, add `value-key` attribute   |                |
|  New feature  |  cascader  |    增加 `fallback` 属性，可以自定义不存在选项的展示           |     Add the `fallback` attribute to customize the display of options that do not exist    |                |
|  New feature  |  cascader  |    增加 `expand-child` 属性，可以展开子菜单      |   Add the `expand-child` property to expand the submenu    |                |
|  Enhancement  |  cascader  |    优化子菜单展开逻辑和键盘事件      |   Optimize submenu expansion logic and keyboard events  |                |
|  Breaking change  |  cascader  |    外露参数从 CascaderOptionInfo 改为 CascaderOption。不再包含内部数据，用户数据不受影响      |    Exposed parameter changed from CascaderOptionInfo to CascaderOption. Internal data is no longer included, user data is not affected   |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
