### PR TITLE
fix(tree): default-expand-selected does not work well with selected-keys

### DIFF
--- a/packages/web-vue/components/tree/tree.vue
+++ b/packages/web-vue/components/tree/tree.vue
@@ -535,7 +535,7 @@ export default defineComponent({
           .filter((node) => node.children && node.children.length)
           .map((node) => node.key);
       }
-      if (defaultSelectedKeys.value || defaultExpandChecked.value) {
+      if (defaultExpandSelected.value || defaultExpandChecked.value) {
         const expandedKeysSet = new Set<TreeNodeKey>([]);
         const addToExpandKeysSet = (keys: TreeNodeKey[]) => {
           keys.forEach((key) => {


### PR DESCRIPTION
修复 `default-expand-selected` 在某些场景没起作用的问题

## Types of changes

- [x] Bug fix

## Background and context
已取消默认展开父节点 (`default-expand-all=false`) ，并设置了默认展开已选中节点 (`default-expand-selected=true`) 和选中节点 (`v-model:selected-keys`)时 ，没有自动展开选中的节点。

问题重现：https://codesandbox.io/s/eager-hill-jlh8kv?file=/src/App.vue




## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   tree   |   修复设置 defaultExpandSelected 失效的问题   |    Fix the problem of setting defaultExpandSelected invalid   |         |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->
