### PR TITLE
feat(modal): modal add hideOk prop

### DIFF
--- a/packages/web-vue/components/modal/README.en-US.md
+++ b/packages/web-vue/components/modal/README.en-US.md
@@ -20,6 +20,8 @@ description: Open a floating layer on the current page to carry related operatio
 
 @import ./__demo__/custom.md
 
+@import ./__demo__/footer.md
+
 @import ./__demo__/form.md
 
 @import ./__demo__/draggable.md
@@ -44,6 +46,7 @@ description: Open a floating layer on the current page to carry related operatio
 |unmount-on-close|Whether to uninstall the node when close|`boolean`|`false`||
 |mask-closable|Whether to close the modal when click the mask|`boolean`|`true`||
 |hide-cancel|Whether to hide the cancel button|`boolean`|`false`||
+|hide-ok|Whether to hide the ok button|`boolean`|`false`||
 |simple|Whether to enable simple mode|`boolean`|`(props: any) => {  return props.notice;}`||
 |closable|Whether to show the close button|`boolean`|`true`||
 |ok-text|The content of the confirm button|`string`|`-`||
@@ -118,6 +121,7 @@ Modal._context = app._context;
 |cancelButtonProps|Props of cancel button|`any`|`-`||
 |okLoading|Whether the confirm button is in the loading state|`boolean`|`false`||
 |hideCancel|Whether to hide the cancel button|`boolean`|`false`||
+|hideOk|Whether to hide the ok button|`boolean`|`false`||
 |mask|Whether to show the mask|`boolean`|`false`||
 |simple|Whether to enable simple mode|`boolean`|`false`||
 |maskClosable|Whether to close the modal when click the mask|`boolean`|`false`||

--- a/packages/web-vue/components/modal/README.zh-CN.md
+++ b/packages/web-vue/components/modal/README.zh-CN.md
@@ -18,6 +18,8 @@ description: 在当前页面打开一个浮层，承载相关操作。
 
 @import ./__demo__/custom.md
 
+@import ./__demo__/footer.md
+
 @import ./__demo__/form.md
 
 @import ./__demo__/draggable.md
@@ -42,6 +44,7 @@ description: 在当前页面打开一个浮层，承载相关操作。
 |unmount-on-close|关闭时是否卸载节点|`boolean`|`false`||
 |mask-closable|是否点击遮罩层可以关闭对话框|`boolean`|`true`||
 |hide-cancel|是否隐藏取消按钮|`boolean`|`false`||
+|hide-ok|是否隐藏确定按钮|`boolean`|`false`||
 |simple|是否开启简单模式|`boolean`|`(props: any) => {  return props.notice;}`||
 |closable|是否显示关闭按钮|`boolean`|`true`||
 |ok-text|确认按钮的内容|`string`|`-`||
@@ -116,6 +119,7 @@ Modal._context = app._context;
 |cancelButtonProps|取消按钮的Props|`any`|`-`||
 |okLoading|确认按钮是否为加载中状态|`boolean`|`false`||
 |hideCancel|是否隐藏取消按钮|`boolean`|`false`||
+|hideOk|是否隐藏确定按钮|`boolean`|`false`||
 |mask|是否显示遮罩层|`boolean`|`false`||
 |simple|是否开启简单模式|`boolean`|`false`||
 |maskClosable|是否点击遮罩层可以关闭对话框|`boolean`|`false`||

--- a/packages/web-vue/components/modal/TEMPLATE.md
+++ b/packages/web-vue/components/modal/TEMPLATE.md
@@ -29,6 +29,8 @@ description: Open a floating layer on the current page to carry related operatio
 
 @import ./__demo__/custom.md
 
+@import ./__demo__/footer.md
+
 @import ./__demo__/form.md
 
 @import ./__demo__/draggable.md

--- a/packages/web-vue/components/modal/__demo__/footer.md
+++ b/packages/web-vue/components/modal/__demo__/footer.md
@@ -1,0 +1,84 @@
+```yaml
+title:
+  zh-CN: 页脚控制
+  en-US: Hide The Footer
+```
+
+## zh-CN
+
+设置 `hideCancel`、 `hideOk`、 `footer` 可以控制页脚内容的显示状态。也可以通过插槽的方式自定义页脚。
+
+---
+
+## en-US
+
+Setting `hideCancel`, `hideOk`and`footer` can control the display status of footer content. You can also customize the footer by slot.
+
+---
+
+```vue
+<template>
+  <a-space style="marginBottom: 20px">
+    <a-typography-text>hideCancel:</a-typography-text>
+    <a-switch v-model="hideCancel" />
+    <a-typography-text>hideOk:</a-typography-text>
+    <a-switch v-model="hideOk" />
+    <a-typography-text>footer:</a-typography-text>
+    <a-switch v-model="hideFooter" />
+    <a-typography-text>slot:</a-typography-text>
+    <a-switch v-model="showFooterSlot" />
+  </a-space>
+  <br />
+  <a-button @click="handleClick">Open Modal</a-button>
+  <a-modal 
+    v-model:visible="visible"
+    :hide-ok="hideOk"
+    :hide-cancel="hideCancel"
+    :footer="hideFooter"
+    @ok="handleOk"
+    @cancel="handleCancel">
+    <template #title>Title</template>
+    <div>You can cusstomize modal body text by the current situation.</div>
+    <template v-if="showFooterSlot" #footer>
+      <a-button type="primary" shape="circle" @click="handleOk">
+        <icon-check />
+      </a-button>
+    </template>
+  </a-modal>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const visible = ref(false);
+    const hideOk = ref(false);
+    const hideCancel = ref(false);
+    const hideFooter = ref(true);
+    const showFooterSlot = ref(false);
+
+    const handleClick = () => {
+      visible.value = true;
+    };
+    const handleOk = () => {
+      visible.value = false;
+    };
+    const handleCancel = () => {
+      visible.value = false;
+    }
+
+    return {
+      visible,
+      hideOk,
+      hideCancel,
+      hideFooter,
+      showFooterSlot,
+      handleClick,
+      handleOk,
+      handleCancel
+    }
+  },
+}
+</script>
+```

--- a/packages/web-vue/components/modal/interface.ts
+++ b/packages/web-vue/components/modal/interface.ts
@@ -54,6 +54,11 @@ export interface ModalConfig {
    */
   hideCancel?: boolean;
   /**
+   * @zh 是否隐藏确定按钮
+   * @en Whether to hide the ok button
+   */
+  hideOk?: boolean;
+  /**
    * @zh 是否显示遮罩层
    * @en Whether to show the mask
    */

--- a/packages/web-vue/components/modal/modal.vue
+++ b/packages/web-vue/components/modal/modal.vue
@@ -83,6 +83,7 @@
                     {{ cancelDisplayText }}
                   </arco-button>
                   <arco-button
+                    v-if="!hideOk"
                     type="primary"
                     v-bind="okButtonProps"
                     :loading="mergedOkLoading"
@@ -227,6 +228,14 @@ export default defineComponent({
      * @en Whether to hide the cancel button
      */
     hideCancel: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * @zh 是否隐藏确定按钮
+     * @en Whether to hide the ok button
+     */
+    hideOk: {
       type: Boolean,
       default: false,
     },


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [x] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context
控制Modal 对话框中确定按钮的显示隐藏
参数名 | 描述 | 类型 | 默认值 | 版本
-- | -- | -- | -- | --
hideOk | 是否隐藏确定按钮 | boolean | false |   

## Solution
Add `hideOk` props to set whether to hide the ok button,And added `footer.md` for the footer section,see below.
在modal组件中新增了hideOk属性，并新增了针对页脚部分的说明文档。预览图在下方。

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   modal    | 添加hideOk属性控制确认按钮显示状态 |  Add hideOk prop to control the status displayed by the confirm button. |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information
<img width="920" alt="image" src="https://user-images.githubusercontent.com/48879481/196474291-2205f5b3-b0b3-4ad7-be6d-d43059ddf8df.png">