### PR TITLE
fix(carousel): transparent background images should be masked

### DIFF
--- a/packages/web-vue/components/carousel/style/index.less
+++ b/packages/web-vue/components/carousel/style/index.less
@@ -36,6 +36,7 @@
   &-slide {
     > *:not(.@{carousel-prefix-cls}-item-current) {
       display: none;
+      visibility: hidden;
     }
 
     .item-position(@direction) {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

close #1900

## Solution

修改 `packages/web-vue/components/carousel/style/index.less` 的内容，添加 `visibility: hidden` 至 `not-item-current`

```less
> *:not(.@{carousel-prefix-cls}-item-current) {
    display: none;
    visibility: hidden;
}
```

## How is the change tested?

## Changelog

| Component | Changelog(CN)                                        | Changelog(EN)                                                | Related issues |
| --------- | ---------------------------------------------------- | ------------------------------------------------------------ | -------------- |
| Carousel  | 修复 `Carousel` 透明背景图片无法遮罩上一张图片的问题 | Fix the problem that the transparent background image of `Carousel` cannot cover the previous image | #1900          |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

原因是切换下一张图片后，上一张图片有以下样式：

```less
  &-slide {
    > *:not(.@{carousel-prefix-cls}-item-current) {
      display: none;
    }
    .item-position(@direction) {
      .@{carousel-prefix-cls}-item-slide-out {
        display: block;
        animation: ~'@{prefix}-carousel-slide-@{direction}-out';
      }
      // 省略无关样式
    }
	// 省略无关样式
  }
```

最终 `item-slide-out` 的 `display` 属性为 `block`，`item-current` 的图片如果为透明背景则无法遮罩。但是无法将 `item-slide-out` 修改为 `display: none`，否则会破坏动画的视觉效果。

因此在下述样式中添加 `visibility: hidden;`

```less
> *:not(.@{carousel-prefix-cls}-item-current) {
    display: none;
}
```



