### PR TITLE
fix(switch): custom color style erro when type is line

### DIFF
--- a/packages/web-vue/components/switch/style/index.less
+++ b/packages/web-vue/components/switch/style/index.less
@@ -253,9 +253,15 @@
   }
 
   &-type-line&-type-line__custom-color {
+    --custom-color: @switch-color-bg_off;
+
     &::after {
       background-color: var(--custom-color);
     }
+  }
+
+  &-type-line&-type-line__custom-color&-checked {
+    --custom-color: @switch-color-bg_on;
   }
 
   &-type-line&-checked &-handle {

--- a/packages/web-vue/components/switch/style/index.less
+++ b/packages/web-vue/components/switch/style/index.less
@@ -252,6 +252,12 @@
     }
   }
 
+  &-type-line&-type-line__custom-color {
+    &::after {
+      background-color: var(--custom-color);
+    }
+  }
+
   &-type-line&-checked &-handle {
     left: calc(100% - @switch-line-size-dot-default);
   }
@@ -311,7 +317,10 @@
       transform: translate(-50%, -50%) scale(1);
     }
   }
+
   &-type-line&-small&-checked &-handle {
-    left: calc(100% - @switch-line-size-dot-small - @switch-size-small-line-gap);
+    left: calc(
+      100% - @switch-line-size-dot-small - @switch-size-small-line-gap
+    );
   }
 }

--- a/packages/web-vue/components/switch/switch.vue
+++ b/packages/web-vue/components/switch/switch.vue
@@ -40,7 +40,7 @@ import { getPrefixCls } from '../_utils/global-config';
 import IconLoading from '../icon/icon-loading';
 import { useFormItem } from '../_hooks/use-form-item';
 import { useSize } from '../_hooks/use-size';
-import { isFunction, isPromise } from '../_utils/is';
+import { isFunction } from '../_utils/is';
 
 export default defineComponent({
   name: 'Switch',
@@ -254,19 +254,21 @@ export default defineComponent({
         [`${prefixCls}-checked`]: computedCheck.value,
         [`${prefixCls}-disabled`]: mergedDisabled.value,
         [`${prefixCls}-loading`]: computedLoading.value,
+        [`${prefixCls}-type-line__custom-color`]:
+          props.type === 'line' && (props.checkedColor || props.uncheckedColor),
       },
     ]);
 
     const buttonStyle = computed(() => {
       if (computedCheck.value && props.checkedColor) {
-        return {
-          backgroundColor: props.checkedColor,
-        };
+        return props.type === 'line'
+          ? { '--custom-color': props.checkedColor }
+          : { backgroundColor: props.checkedColor };
       }
       if (!computedCheck.value && props.uncheckedColor) {
-        return {
-          backgroundColor: props.uncheckedColor,
-        };
+        return props.type === 'line'
+          ? { '--custom-color': props.uncheckedColor }
+          : { backgroundColor: props.uncheckedColor };
       }
       return undefined;
     });


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|   Switch  |  修复类型为`line`时自定义颜色样式错误的问题  | Fix the problem that the custom color style is wrong when the type is `line` |  Close #2039   |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->

## Checklist:

- [x] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

### Before
![before](https://user-images.githubusercontent.com/24789441/211990063-68629b75-89f9-4a22-b7ff-830fe7583ef5.png)

### After
![after](https://user-images.githubusercontent.com/24789441/211990077-1467e685-2c88-4414-8ca1-168d6dce1cbe.png)


<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
