### PR TITLE
修复Modal组件设置width属性后，fullscreen 宽度失效的问题

### DIFF
--- a/packages/web-vue/components/modal/modal.vue
+++ b/packages/web-vue/components/modal/modal.vue
@@ -687,7 +687,8 @@ export default defineComponent({
       const style: CSSProperties = {
         ...(props.modalStyle ?? {}),
       };
-      if (props.width) {
+      // 修复设置width属性后，全屏无法生效的问题
+      if (props.width && !fullscreen) {
         style.width = isNumber(props.width) ? `${props.width}px` : props.width;
       }
       if (!props.alignCenter && props.top) {


### PR DESCRIPTION
[在线地址](https://codesandbox.io/s/elated-payne-19x7vz?file=/src/App.vue)