### PR TITLE
fix(select): do not close the dropdown after selecting when popup bind to itself

### DIFF
--- a/packages/web-vue/components/trigger/trigger.tsx
+++ b/packages/web-vue/components/trigger/trigger.tsx
@@ -517,7 +517,12 @@ export default defineComponent({
       }
       if (triggerMethods.value.includes('click')) {
         updateMousePosition(e);
-        changeVisible(!computedVisible.value);
+        // https://github.com/arco-design/arco-design-vue/issues/2564
+        if (popupRef.value?.contains(e.target as HTMLElement)) {
+          changeVisible(false);
+        } else {
+          changeVisible(!computedVisible.value);
+        }
       } else if (
         triggerMethods.value.includes('contextMenu') &&
         computedVisible.value


### PR DESCRIPTION
## Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

fix #2564 

## Solution

如果挂到 `<a-select>` 自己，会导致用户选择后触发 `MouseEvent`，而正常情况下不会。

观察到 `MouseEvent` 的 `target` 是点击的选项，所以在处理 `MouseEvent` 时判断 `target` 是否 `popup` 的子节点。
如果是子节点，说明点击事件发生在 `popup` 中，也就是点击了选项，那就应该 `changeVisible(false)`。
如果不是子节点，说明一切正常。

## How is the change tested?

see #2564 

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| select | 修复 `popup-container` 绑定到自己时错误 | fix the bug of not close the dropdown after selecting when popup bind to itself | #2564 |

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)
