### PR TITLE
fix(avatar-group): fix partial avatars not displaying in the avatar group popover

### DIFF
--- a/packages/web-vue/components/avatar/avatar-group.tsx
+++ b/packages/web-vue/components/avatar/avatar-group.tsx
@@ -97,8 +97,8 @@ const AvatarGroup = defineComponent({
       const avatarsInPopover =
         props.maxCount > 0 ? children.slice(props.maxCount) : [];
 
-      if (total.value !== avatarsToRender.length) {
-        total.value = avatarsToRender.length;
+      if (total.value !== children.length) {
+        total.value = children.length;
       }
 
       return (
@@ -109,7 +109,7 @@ const AvatarGroup = defineComponent({
               v-slots={{
                 content: () => <div>{avatarsInPopover}</div>,
               }}
-              {...(props.maxPopoverTriggerProps as unknown)}
+              {...props.maxPopoverTriggerProps}
             >
               <Avatar
                 class={`${prefixCls}-max-count-avatar`}


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

当省略的头像数量大于最大显示数时，z-index会成为负数导致无法正常显示。
![image](https://github.com/arco-design/arco-design-vue/assets/48879481/75ff9a34-6a3f-443f-b6c4-0cbfbcdd7933)

## Solution


## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  avatar-group         |   修复头像组气泡中部分头像不显示问题      |      fix partial avatars not displaying in the avatar group popover         |     #2745         | 

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
