### PR TITLE
fix(input-number): fix overlap between step button and suffix/append

### DIFF
--- a/packages/web-vue/components/input-number/input-number.tsx
+++ b/packages/web-vue/components/input-number/input-number.tsx
@@ -466,7 +466,9 @@ export default defineComponent({
       }
       return (
         <>
-          {slots.suffix?.()}
+          {slots.suffix && (
+            <div class={`${prefixCls}-suffix`}>{slots.suffix?.()}</div>
+          )}
           <div class={`${prefixCls}-step`}>
             <button
               class={[

--- a/packages/web-vue/components/input-number/style/index.less
+++ b/packages/web-vue/components/input-number/style/index.less
@@ -49,6 +49,10 @@
     }
   }
 
+  .@{input-prefix-cls}-wrapper {
+    position: relative;
+  }
+
   &-prefix,
   &-suffix {
     .transition();
@@ -92,13 +96,18 @@
     &:not(.@{input-prefix-cls}-disabled):not(.@{input-prefix-cls}-outer-disabled) {
       &:hover,
       &:focus-within {
+        // 修正 hove 时存在 suffix 但隐藏了，视觉上 padding 过大问题
+        .@{input-prefix-cls}-suffix:has(.@{input-number-prefix-cls}-suffix) {
+          padding-left: @spacing-2;
+        }
+
         & .@{input-number-prefix-cls}-step {
           opacity: 1;
+        }
 
-          & ~ .@{input-prefix-cls}-suffix {
-            opacity: 0;
-            pointer-events: none;
-          }
+        & .@{input-number-prefix-cls}-suffix {
+          opacity: 0;
+          pointer-events: none;
         }
       }
     }


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

开启 `suffix` 插槽或者 `append` 时会出现步进按钮重叠。

问题描述 #2999 
相关 PR #3003

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
原本的样式代码中有相关的实现但有缺陷未生效。
针对 vue 版实现修改最终与React [demo](https://codesandbox.io/p/sandbox/frosty-smoke-wmvvm3) 效果一致。

未hover 时：

<img width="410" alt="image" src="https://github.com/arco-design/arco-design-vue/assets/48879481/2e9ffc41-4982-4868-a7b1-80df653c1ffe">

hover 时：
<img width="442" alt="image" src="https://github.com/arco-design/arco-design-vue/assets/48879481/82a3beea-fa7a-44b3-a655-b8bbdd0e8925">

https://github.com/arco-design/arco-design-vue/assets/48879481/547cf1de-a50a-482f-88e1-5c7a4f62022d

## How is the change tested?

snapshots没变化

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  input-number  |   修复步进按钮与 suffix/append 的样式重叠     |   fix overlap between step button and suffix/append   |   Closes #2999             |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
