### PR TITLE
fix(color-picker): fix v-model not working

### DIFF
--- a/packages/web-vue/components/color-picker/color-picker.tsx
+++ b/packages/web-vue/components/color-picker/color-picker.tsx
@@ -5,7 +5,6 @@ import { colors } from './colors';
 import { HSV } from './interface';
 import Panel from './panel';
 import Trigger, { TriggerProps } from '../trigger';
-import useMergeState from '../_hooks/use-merge-state';
 import useState from '../_hooks/use-state';
 import {
   formatInputToHSVA,
@@ -133,10 +132,9 @@ export default defineComponent({
   },
   setup(props, { emit, slots }) {
     const prefixCls = getPrefixCls('color-picker');
-    const [mergeValue, setMergeValue] = useMergeState(
-      props.defaultValue,
-      reactive({ value: props.modelValue })
-    );
+    const mergeValue = computed(() => {
+      return props.modelValue ?? props.defaultValue;
+    });
 
     const formatInput = computed(() => {
       return formatInputToHSVA(mergeValue.value || '');
@@ -148,6 +146,18 @@ export default defineComponent({
       s: formatInput.value.s,
       v: formatInput.value.v,
     });
+
+    watch(
+      () => formatInput.value,
+      (value) => {
+        setAlpha(value.a);
+        setHsv({
+          h: value.h,
+          s: value.s,
+          v: value.v,
+        });
+      }
+    );
 
     const color = computed(() => {
       const rgb = hsvToRgb(hsv.value.h, hsv.value.s, hsv.value.v);
@@ -177,7 +187,6 @@ export default defineComponent({
     });
 
     watch(formatValue, (value) => {
-      setMergeValue(value);
       emit('update:modelValue', value);
       emit('change', value);
     });


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

双向绑定失效
modelValue更新后未及时更新组件内部相关变量

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    color-picker       |     修复双向绑定不生效问题        |      fix v-model not working         |  Closes #3029   |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
