### PR TITLE
fix(empty): fix automatically inherited warn

### DIFF
--- a/packages/web-vue/components/empty/empty.tsx
+++ b/packages/web-vue/components/empty/empty.tsx
@@ -6,6 +6,7 @@ import { configProviderInjectionKey } from '../config-provider/context';
 
 export default defineComponent({
   name: 'Empty',
+  inheritAttrs: false,
   props: {
     /**
      * @zh 描述内容
@@ -32,7 +33,7 @@ export default defineComponent({
    * @en Image/Icon
    * @slot image
    */
-  setup(props, { slots }) {
+  setup(props, { slots, attrs }) {
     const prefixCls = getPrefixCls('empty');
     const { t } = useI18n();
     const configCtx = inject(configProviderInjectionKey, undefined);
@@ -47,7 +48,7 @@ export default defineComponent({
       }
 
       return (
-        <div class={prefixCls}>
+        <div class={prefixCls} {...attrs}>
           <div class={`${prefixCls}-image`}>
             {slots.image?.() ??
               (props.imgSrc ? (


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context
`empty` 组件在全局配置 `ConfigProvider` 设置了自定义空状态后会出现继承警告问题

> [!WARNING]
> [Vue warn]: Extraneous non-props attributes (**xxxx**) were passed to component but could not be automatically inherited because component renders fragment or text root nodes.

当使用 `configCtx.slots.empty` 自定义空状态时无法确定是否是单个根节点
https://github.com/arco-design/arco-design-vue/blob/faf3ce8cdb10bdda25b5217d6c13c0d7ce2e95c7/packages/web-vue/components/empty/empty.tsx#L41-L47

## Solution
直接添加一个层包裹可以解决但层级结构变了 怕影响大
```jsx
return <div>{configCtx.slots.empty({ component: 'empty' })}</div>
``` 

该 PR 采用手动选择性继承，影响范围与之前一致


## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    empty       |    修复属性自动继承的错误           |   fix automatically inherited warn   |    Closes #3034             |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
