### PR TITLE
fix(input): fix display of allow-clear input button in read-only state

### DIFF
--- a/packages/web-vue/components/input/input.tsx
+++ b/packages/web-vue/components/input/input.tsx
@@ -215,6 +215,7 @@ export default defineComponent({
     const showClearBtn = computed(
       () =>
         props.allowClear &&
+        !props.readonly &&
         !mergedDisabled.value &&
         Boolean(computedValue.value)
     );


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

在只读状态下开启 `allow-clear` 依然会显示清空按钮可清空输入框内容

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  input   |  修复只读状态下显示清空输入框按钮  | fix display of allow-clear input button in read-only state |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
