### PR TITLE
fix: 导致用户自己设置的dataTransfer.setData('text/plain')失效

### DIFF
--- a/packages/web-vue/components/tree/base-node.vue
+++ b/packages/web-vue/components/tree/base-node.vue
@@ -354,8 +354,6 @@ export default defineComponent({
 
         e.stopPropagation();
 
-        setDragStatus('dragStart', e);
-
         try {
           // ie throw error
           // firefox-need-it
@@ -363,6 +361,8 @@ export default defineComponent({
         } catch (error) {
           // empty
         }
+
+        setDragStatus('dragStart', e);
       },
       onDragEnd(e: DragEvent) {
         if (!draggable.value) return;


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation change
- [ ] Coding style change
- [ ] Component style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change
- [ ] Others 

## Background and context

在tree onDragStart 事件 dataTransfer.setData('text/plain')设置不上

## Solution

emit之前去设置node的dataTransfer.setData

## How is the change tested?


## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|  Tree         |      修复 onDragStart   dataTransfer.setData 不生效       |               |                |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `main` branch)

## Other information

