### PR TITLE
fix(switch): loading state can't be controlled with truthy initial state

### DIFF
--- a/packages/web-vue/components/switch/switch.vue
+++ b/packages/web-vue/components/switch/switch.vue
@@ -223,7 +223,7 @@ export default defineComponent({
     const computedCheck = computed<boolean>(
       () => (props.modelValue ?? _checked.value) === props.checkedValue
     );
-    const _loading = ref(props.loading);
+    const _loading = ref(false);
     const computedLoading = computed(() => _loading.value || props.loading);
 
     const handleChange = (checked: boolean, ev: Event) => {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->
如果给 Switch 组件的 loading 传入初始状态为 true 的 Ref，内部的 _loading 会被初始化为 true，此时如果外部的 loading 变回 false 则 Switch 组件仍会处于 loading 状态，导致组件的 loading 态不受控。

If you pass a Ref to the loading of the Switch component with an initial state of `true`, the internal ref `_loading` will be initialized with `true`, then if the external loading ref changed to false, the Switch component will still be in the loading state, resulting in an uncontrolled loading state.

```ts
// script
const loading = ref(true);

// template
<a-button @click="loading = !loading">{{ loading }}</a-button>
<a-switch :loading="loading" />
```
![20240829192136_rec_](https://github.com/user-attachments/assets/aa4942aa-9310-41fe-9b59-97c11b91b230)

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->
![20240829192738_rec_](https://github.com/user-attachments/assets/99c1e682-a4f3-450d-bde6-29fd0c7ba30f)

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Select  | fix(switch): 修复当加载状态被真值初始化后无法受控 | fix(switch): loading state can't be controlled with truthy initial state|                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
