### PR TITLE
fix(docs): replace unpkg in codepen w/ jsdelivr

### DIFF
--- a/packages/arco-vue-docs/utils/codepen.ts
+++ b/packages/arco-vue-docs/utils/codepen.ts
@@ -1,11 +1,11 @@
 const CSS_EXTERNAL = [
-  'https://unpkg.com/@arco-design/web-vue@2.x/dist/arco.css',
+  'https://cdn.jsdelivr.net/npm/@arco-design/web-vue@2.x/dist/arco.css',
 ];
 const JS_EXTERNAL = [
-  'https://unpkg.com/vue@3.x/dist/vue.global.prod.js',
-  'https://unpkg.com/dayjs@1.x/dayjs.min.js',
-  'https://unpkg.com/@arco-design/web-vue@2.x/dist/arco-vue.min.js',
-  'https://unpkg.com/@arco-design/web-vue@2.x/dist/arco-vue-icon.min.js',
+  'https://cdn.jsdelivr.net/npm/vue@3.x/dist/vue.global.prod.js',
+  'https://cdn.jsdelivr.net/npm/dayjs@1.x/dayjs.min.js',
+  'https://cdn.jsdelivr.net/npm/@arco-design/web-vue@2.x/dist/arco-vue.min.js',
+  'https://cdn.jsdelivr.net/npm/@arco-design/web-vue@2.x/dist/arco-vue-icon.min.js',
 ];
 
 const parseContent = (content: string) => {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [x] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

UNPKG has not been actively maintained and has been down since `Mar 15, 2025` (https://github.com/unpkg/unpkg/issues/412).

This breaks existing codepens.

## Solution

The PR replaces UNPKG usage with jsDelivr so that codepen works again.

## How is the change tested?

This can be tested by spinning up the local development environment and see if the newly created codepen works or not.

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|           |               |               |                |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->

## Checklist:

- [x] Test suite passes (`npm run test`)
- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
