### PR TITLE
feat(calendar): add content slot to render schedule

### DIFF
--- a/packages/web-vue/components/calendar/__demo__/basic.md
+++ b/packages/web-vue/components/calendar/__demo__/basic.md
@@ -19,7 +19,16 @@ Display and select calendars
 ```vue
 
 <template>
-  <a-calendar v-model="value" />
+  <a-calendar v-model="value">
+    <template #content="{ year, month, date }">
+      <a-tag v-if="`${year}-${month}-${date}` === '2023-1-1'" color="orange" style="width: 100%; margin-top: 10px; border-radius: 10px;">
+        <template #icon>
+          <icon-star/>
+        </template>
+        结婚纪念日
+      </a-tag>
+    </template>
+  </a-calendar>
   select: {{value}}
 </template>
 

--- a/packages/web-vue/components/calendar/calendar.tsx
+++ b/packages/web-vue/components/calendar/calendar.tsx
@@ -256,7 +256,7 @@ export default defineComponent({
               isWeek={props.isWeek}
               dayStartOfWeek={props.dayStartOfWeek}
               pageShowDate={pageShowDate.value}
-              v-slots={{ default: slots.default }}
+              v-slots={{ default: slots.default, content: slots.content }}
             />
           </div>
         )}

--- a/packages/web-vue/components/calendar/month.tsx
+++ b/packages/web-vue/components/calendar/month.tsx
@@ -164,6 +164,11 @@ export default defineComponent({
                     ) : (
                       <div class={`${prefixCls}-date-circle`}>{col.date}</div>
                     )}
+                    {slots.content?.({
+                      year: col.year,
+                      month: col.month,
+                      date: col.date,
+                    })}
                   </div>
                 </div>
               )}


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

`Calendar`组件如果通过`default `插槽来实现日程（比如国定假日、节气、备注）的展示，会失去默认的日期点击事件。
https://github.com/arco-design/arco-design-vue/issues/3464

## Solution

新增`content`插槽，实现日程展示，保留默认的日期展示与点击事件。

## How is the change tested?

人工测试来保证新增的slot正常工作，不影响其他内容。

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|      `Calendar`    |      新增 `content` 插槽         |      Added `content` slot         |      Close    https://github.com/arco-design/arco-design-vue/issues/3464       |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

这个PR能够让`Calendar`提供类似日程的功能，而保留默认的日期展示、事件点击，便于开发者使用
