### PR TITLE
Don't update global dayjs locale but make sure dayStartOfWeek can work properly

### DIFF
--- a/.cursorindexingignore
+++ b/.cursorindexingignore
@@ -1,0 +1,2 @@
+# Don't index SpecStory auto-save files, but allow explicit context inclusion via @ references
+.specstory/**

--- a/.cursorindexingignore
+++ b/.cursorindexingignore
@@ -1,2 +1,0 @@
-# Don't index SpecStory auto-save files, but allow explicit context inclusion via @ references
-.specstory/**

--- a/packages/web-vue/components/date-picker/panels/date/index.vue
+++ b/packages/web-vue/components/date-picker/panels/date/index.vue
@@ -78,7 +78,7 @@ import { Dayjs } from 'dayjs';
 import { RenderFunc } from '../../../_components/render-function';
 import { TimePickerProps } from '../../../time-picker/interface';
 import { getPrefixCls } from '../../../_utils/global-config';
-import { getDateValue, getNow, methods } from '../../../_utils/date';
+import { getDateValue, getNow, methods, dayjs } from '../../../_utils/date';
 import type {
   Cell,
   DisabledDate,
@@ -98,6 +98,7 @@ import IconCalendar from '../../../icon/icon-calendar';
 import IconClockCircle from '../../../icon/icon-clock-circle';
 import useMergeState from '../../../_hooks/use-merge-state';
 import useDatePickerTransform from '../../hooks/use-inject-datepicker-transform';
+import { useI18n } from '../../../locale';
 
 const ROW_COUNT = 6;
 const COL_COUNT = 7;
@@ -273,13 +274,19 @@ export default defineComponent({
         };
       }
 
+      const { locale: globalLocal } = useI18n();
       const rows = newArray(ROW_COUNT).map((_, index) => {
         const row = flatData.slice(index * COL_COUNT, (index + 1) * COL_COUNT);
         if (isWeek.value) {
           // 取第一个作为周 cell 的值
           const valueOfWeek = row[0].value;
           row.unshift({
-            label: valueOfWeek.week(),
+            label: valueOfWeek
+              .locale({
+                ...dayjs.Ls[globalLocal.value.toLocaleLowerCase()],
+                weekStart: dayStartOfWeek.value,
+              })
+              .week(),
             value: valueOfWeek,
           });
         }

--- a/packages/web-vue/components/date-picker/picker.vue
+++ b/packages/web-vue/components/date-picker/picker.vue
@@ -70,7 +70,7 @@ import {
   getNow,
   isValueChange,
   getDateValue,
-  initializeDateLocale,
+  // initializeDateLocale,
 } from '../_utils/date';
 import { getPrefixCls } from '../_utils/global-config';
 import useState from '../_hooks/use-state';
@@ -101,7 +101,7 @@ import { mergeValueWithTime } from './utils';
 import { Size } from '../_utils/constant';
 import { useReturnValue } from './hooks/use-value-format';
 import { useFormItem } from '../_hooks/use-form-item';
-import { useI18n } from '../locale';
+// import { useI18n } from '../locale';
 
 /**
  * @displayName Common
@@ -473,10 +473,10 @@ export default defineComponent({
       showConfirmBtn,
     } = toRefs(props);
 
-    const { locale: globalLocal } = useI18n();
-    watchEffect(() => {
-      initializeDateLocale(globalLocal.value, dayStartOfWeek.value);
-    });
+    // const { locale: globalLocal } = useI18n();
+    // watchEffect(() => {
+    //   initializeDateLocale(globalLocal.value, dayStartOfWeek.value);
+    // });
 
     const { mergedDisabled, eventHandlers } = useFormItem({ disabled });
 

--- a/packages/web-vue/components/date-picker/range-picker.vue
+++ b/packages/web-vue/components/date-picker/range-picker.vue
@@ -88,7 +88,7 @@ import {
   dayjs,
   getNow,
   getDateValue,
-  initializeDateLocale,
+  // initializeDateLocale,
 } from '../_utils/date';
 import useState from '../_hooks/use-state';
 import {
@@ -435,9 +435,9 @@ export default defineComponent({
 
     const { locale: globalLocal } = useI18n();
     const configCtx = inject(configProviderInjectionKey, undefined);
-    watchEffect(() => {
-      initializeDateLocale(globalLocal.value, dayStartOfWeek.value);
-    });
+    // watchEffect(() => {
+    //   initializeDateLocale(globalLocal.value, dayStartOfWeek.value);
+    // });
 
     const mergedExchangeTime = computed(() => {
       return !(!exchangeTime.value || !(configCtx?.exchangeTime ?? true));


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

fixing for: 
- #3021 
- #3039
- #3509 

Basically, I don't think we need to update global dayjs locale with dayStartOfWeek set in date-picker component, doing this will make impact on global dayjs component. And we can see the inconsistent behaviors caused by this action in issue #3509. 

## Solution

- Don't update global dayjs locale with dayStartOfWeek value passed to date-picker
- But when getting week in year value when rendering week picker, make sure dayStartOfWeek get considered properly

## How is the change tested?

Check the two week pickers in date-picker page, when `dayStartOfWeek` is 0, 2025 has 53 weeks, at the second week picker with `dayStartOfWeek = 1` , we should have 52 weeks in 2025.

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| date-picker  | 不修改dayjs全局locale配置               | Don't change global dayjs locale settings               |  #3021, #3039, #3509              |
