### PR TITLE
fix(upload): 修复upload组件show-retry-button属性值为false时，在文件列表状态不生效的情况；

### DIFF
--- a/packages/web-vue/components/upload/upload-progress.tsx
+++ b/packages/web-vue/components/upload/upload-progress.tsx
@@ -30,15 +30,14 @@ export default defineComponent({
     const uploadCtx = inject(uploadInjectionKey, undefined);
 
     const renderIcon = () => {
-      if (props.file.status === 'error') {
+      if (props.file.status === 'error' && uploadCtx?.showRetryButton) {
         return (
           <span
             class={[uploadCtx?.iconCls, `${uploadCtx?.iconCls}-upload`]}
             onClick={() => uploadCtx?.onUpload(props.file)}
           >
-            {(uploadCtx?.showRetryButton &&
-              (uploadCtx?.slots['retry-icon']?.() ??
-                uploadCtx?.customIcon?.retryIcon?.())) ||
+            {(uploadCtx?.slots['retry-icon']?.() ??
+              uploadCtx?.customIcon?.retryIcon?.()) ||
             props.listType === 'picture-card' ? (
               <IconUpload />
             ) : (


### PR DESCRIPTION
upload组件的show-retry-button在文件列表状态下，判断条件错误，无法隐藏‘点击重试’文案。
期望是该属性false时，隐藏‘重新上传‘相关的按钮和文案。
所以修改了判断条件。