### PR TITLE
fix(color-picker): 修复color-picker的 "预设颜色和最近使用颜色" 功能 对部分值无法正确格式化的问题

### DIFF
--- a/packages/web-vue/components/color-picker/panel.tsx
+++ b/packages/web-vue/components/color-picker/panel.tsx
@@ -1,6 +1,6 @@
 import { PropType, computed, defineComponent, ref } from 'vue';
 import { getPrefixCls } from '../_utils/global-config';
-import { hexToRgb, rgbToHsv } from '../_utils/color';
+import { formatInputToHSVA } from '../_utils/color';
 import { Color, HSV } from './interface';
 import { useI18n } from '../locale';
 import useState from '../_hooks/use-state';
@@ -45,9 +45,9 @@ export default defineComponent({
     const showCopy = ref(false);
 
     const onHexInputChange = (value: string) => {
-      const _rgb = hexToRgb(value) || { r: 255, g: 0, b: 0 };
-      const _hsv = rgbToHsv(_rgb.r, _rgb.g, _rgb.b);
+      const _hsv = formatInputToHSVA(value);
       props.onHsvChange?.(_hsv);
+      props.onAlphaChange?.(_hsv.a);
     };
 
     const renderInput = () => {


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->
color-picker 提供了history-colors 和 preset-colors两个props。当传入的值为rgb或者带不透明度的16进制值时，如果用户选择这部分颜色，组件的rgb值为红色，而不透明度不会变化
## Solution

<!-- Describe how the problem is fixed in detail -->
在packages/web-vue/components/color-picker/panel.tsx中，修改了onHexInputChange方法的格式化颜色的代码，保证颜色的正常格式化，同时，额外调用onAlphaChange触发不透明度的更新
## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->
为history-colors 或者 preset-colors传入带有不透明度的16进制颜色值，或者rgb值，并在界面上选择这部分颜色即可复现。官网有提供"预设颜色和历史颜色"的示例，可以选择一个带不透明度的颜色值以将其添加到历史，再从历史中选中
## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| color-picker | 修复color-picker的 "预设颜色和最近使用颜色" 功能 对部分值无法正确格式化的问题 | Resolve the formatting issue in the color-picker's 'preset and recent colors' functionality for certain values. | |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
