### PR TITLE
fix(input-number): input number 输入 0.00000001 会自动变成科学计数法

### DIFF
--- a/packages/web-vue/components/input-number/__test__/index.test.ts
+++ b/packages/web-vue/components/input-number/__test__/index.test.ts
@@ -30,4 +30,56 @@ describe('InputNumber', () => {
     await input.trigger('blur');
     expect(input.element.value).toBe('10');
   });
+
+  test('init value with scientific notation', () => {
+    const wrapper1 = mount(InputNumber, {
+      props: {
+        defaultValue: 1.234e5,
+      },
+    });
+    expect(wrapper1.find('input').element.value).toBe('123400');
+
+    const wrapper2 = mount(InputNumber, {
+      props: {
+        defaultValue: -2.34e-5,
+      },
+    });
+    expect(wrapper2.find('input').element.value).toBe('-0.0000234');
+
+    const wrapper3 = mount(InputNumber, {
+      props: {
+        defaultValue: -0.000000000000000000001,
+      },
+    });
+    expect(wrapper3.find('input').element.value).toBe(
+      '-0.000000000000000000001'
+    );
+
+    const wrapper4 = mount(InputNumber, {
+      props: {
+        defaultValue: 10000000000000000000000,
+      },
+    });
+    expect(wrapper4.find('input').element.value).toBe(
+      '10000000000000000000000'
+    );
+
+    const wrapper5 = mount(InputNumber, {
+      props: {
+        defaultValue: -10000000000000000000000,
+      },
+    });
+    expect(wrapper5.find('input').element.value).toBe(
+      '-10000000000000000000000'
+    );
+  });
+
+  test('should handle very small numbers without scientific notation', () => {
+    const wrapper = mount(InputNumber, {
+      props: {
+        defaultValue: 0.00000001,
+      },
+    });
+    expect(wrapper.find('input').element.value).toBe('0.00000001');
+  });
 });

--- a/packages/web-vue/components/input-number/input-number.tsx
+++ b/packages/web-vue/components/input-number/input-number.tsx
@@ -12,6 +12,7 @@ import { Size } from '../_utils/constant';
 import { useFormItem } from '../_hooks/use-form-item';
 import { useSize } from '../_hooks/use-size';
 import { getKeyDownHandler, KEYBOARD_KEY } from '../_utils/keyboard';
+import { toFixed, toSafeString } from './utils';
 
 type StepMethods = 'minus' | 'plus';
 
@@ -261,7 +262,7 @@ export default defineComponent({
 
       const numString = mergedPrecision.value
         ? number.toFixed(mergedPrecision.value)
-        : String(number);
+        : toSafeString(number);
       return props.formatter?.(numString) ?? numString;
     };
 

--- a/packages/web-vue/components/input-number/utils.ts
+++ b/packages/web-vue/components/input-number/utils.ts
@@ -1,0 +1,48 @@
+import NP from 'number-precision';
+
+/**
+ * Replace number.toFixed with Math.round
+ */
+export function toFixed(number: number, precision: number): string {
+  const pow = 10 ** precision;
+  return (Math.round(number * pow) / pow).toFixed(precision);
+}
+
+/**
+ * Convert number to non-scientific notation
+ */
+export function toSafeString(number: number | string): string {
+  // Use native Number.toString when it is NaN or non-scientific notation
+  const nativeNumberStr = number.toString();
+  if (Number.isNaN(+number) || !nativeNumberStr.includes('e')) {
+    return nativeNumberStr;
+  }
+
+  try {
+    const isNegative = number < 0;
+    const absoluteValue = Math.abs(+number);
+    // Get decimal length
+    const digitLength = NP.digitLength(absoluteValue);
+    // Convert decimal to integer
+    const integerNum = NP.float2Fixed(absoluteValue);
+    // Convert integer to non-scientific notation string
+    const integerStr = integerNum
+      .toString()
+      .replace(/e\+(\d+)/i, (_, $1) => new Array(+$1).fill(0).join(''));
+
+    return `${isNegative ? '-' : ''}${
+      digitLength === 0
+        ? integerStr
+        : integerStr.replace(new RegExp(`\\d{1,${digitLength}}$`), (match) => {
+            const decimalStr = `${new Array(digitLength)
+              .fill(0)
+              .join('')}${match}`.slice(-digitLength);
+            return `${integerStr.length <= digitLength ? 0 : ''}.${decimalStr}`;
+          })
+    }`;
+  } catch (e) {
+    // If any error occurs, fallback to native string conversion
+  }
+
+  return nativeNumberStr;
+}


### PR DESCRIPTION

## Types of changes

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context
input number 组件输入小数会变成科学计数法，0.000000001 -> 1e-8 , 这是机器影响用户体验。 
并且 react 版本并不存在这个问题。
经过搜索发现早期 arco-design-vue是修复过这个问题的 https://github.com/arco-design/arco-design/pull/865

问题复现路径：
在文档中就能复现
<img width="2709" height="1642" alt="image" src="https://github.com/user-attachments/assets/3f4046a3-b0b5-4477-8724-009de830b10d" />

 
## Solution

- 新增 `toSafeString` 工具函数来处理科学计数法转换
- 修改 `getStringValue` 函数，使用 `toSafeString` 替代原生的 `String()` 方法
- 使用 `number-precision` 库确保精确的数值转换

- 📁 `packages/web-vue/components/input-number/utils.ts` - 新增工具函数
- 📁 `packages/web-vue/components/input-number/input-number.tsx` - 修改核心逻辑
- 📁 `packages/web-vue/components/input-number/__test__/index.test.ts` - 添加测试用例

## How is the change tested?

添加并通过了组件测试用例。

1.234e5 => 123400

-0.000000000000000000001 => -0.000000000000000000001
等，具体文件在 packages/web-vue/components/input-number/__test__/index.test.ts`

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
|    InputNumber       |       InputNumber 组件始终使用非科学计数法展示数值。        |       The InputNumber component always displays numbers in non-scientific notation.        |        https://github.com/arco-design/arco-design-vue/issues/3599        |



## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)


