### PR TITLE
fix(mention): 清除输入后关闭弹出层并重置测量信息

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -39,6 +39,7 @@
 *.md              text eol=lf
 *.vue             text eol=lf
 *.tsx             text eol=lf
+*.snap            text eol=lf
 
 # Scripts
 *.bash            text eol=lf

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,6 +4,6 @@ module.exports = {
   printWidth: 80,
   singleQuote: true,
   quoteProps: 'consistent',
-  endOfLine: 'auto',
+  endOfLine: 'lf',
   htmlWhitespaceSensitivity: 'strict',
 };

--- a/packages/web-vue/components/mention/__test__/index.test.ts
+++ b/packages/web-vue/components/mention/__test__/index.test.ts
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
 import Mention from '../index';
 
 describe('Mention', () => {
@@ -37,5 +38,29 @@ describe('Mention', () => {
     );
     await input.trigger('keydown', { key: 'Enter' });
     expect(wrapper.emitted('change')?.[1]).toEqual(['@Bytedance']);
+  });
+
+  test('should close popup after clear', async () => {
+    const wrapper = mount(Mention, {
+      props: {
+        data: ['Bytedance', 'Bytedesign', 'Bytenumner'],
+        allowClear: true,
+      },
+      attachTo: document.body,
+    });
+    const input = wrapper.find('input');
+    await input.trigger('focusin');
+    await input.setValue('@');
+    await nextTick();
+
+    const triggerVm = wrapper.findComponent({ name: 'Trigger' }).vm as any;
+    expect(triggerVm.$props.popupVisible).toBe(true);
+
+    const clearBtn = wrapper.find('.arco-input-clear-btn');
+    await clearBtn.trigger('mousedown');
+    await clearBtn.trigger('click');
+    await nextTick();
+
+    expect(triggerVm.$props.popupVisible).toBe(false);
   });
 });

--- a/packages/web-vue/components/mention/mention.tsx
+++ b/packages/web-vue/components/mention/mention.tsx
@@ -228,6 +228,8 @@ export default defineComponent({
 
     const handleClear = (ev: Event) => {
       _value.value = '';
+      resetMeasureInfo();
+      _popupVisible.value = false;
       emit('update:modelValue', '');
       emit('change', '');
       eventHandlers.value?.onChange?.();


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

修复 `Mention` 组件在 `allow-clear` 清空输入后，下拉提及弹窗仍然显示的问题。  
关联 issue：https://github.com/arco-design/arco-design-vue/issues/3650

另外处理了 Vitest 下快照文件在 Windows 环境中出现“内容未变但 Git 显示变更”的换行符不一致问题，减少跨平台噪音改动。

## Solution

<!-- Describe how the problem is fixed in detail -->

1. 在 `Mention` 的清空逻辑中，清空输入值时同步重置提及测量状态并关闭弹窗：
   - `resetMeasureInfo()`
   - `_popupVisible.value = false`

2. 新增回归测试，覆盖“输入 `@` 后点击清空，弹窗应关闭”的场景。

3. 统一快照换行策略，避免 Windows 下 CRLF/LF 导致的假变更：
   - `.prettierrc.js`：`endOfLine` 调整为 `lf`
   - `.gitattributes`：新增 `*.snap text eol=lf`

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

- 新增并执行 `mention` 相关单测：
  - `pnpm --filter @arco-design/web-vue exec vitest run components/mention/__test__/index.test.ts`
- 测试结果：
  - `components/mention/__test__/index.test.ts` 共 3 个用例全部通过（包含新增清空场景回归用例）。

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Mention | 修复 Mention 在输入 `@` 后点击清空按钮仍显示提及下拉弹窗的问题。 | Fix issue where Mention dropdown remains visible after clearing input triggered by `allow-clear` after typing `@`. | #3650 |
| Repo Config | 统一 Vitest 快照换行为 LF，修复 Windows 下快照文件“无内容变化却被标记修改”的问题。 | Normalize Vitest snapshot line endings to LF to avoid false snapshot diffs on Windows. | - |

<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->

本次变更不涉及 breaking change。  
快照换行策略改为 LF 后，macOS/Linux 不受影响，Windows 环境下可减少无效快照改动。