### PR TITLE
fix(textarea): update value before input event

### DIFF
--- a/packages/web-vue/components/textarea/__test__/index.test.ts
+++ b/packages/web-vue/components/textarea/__test__/index.test.ts
@@ -20,4 +20,47 @@ describe('Textarea', () => {
     await wrapper.find('.arco-textarea-clear-btn').trigger('click');
     expect(textarea.element.value).toBe('');
   });
+
+  test('should update model before input event handlers run', async () => {
+    let modelValue = '';
+    let modelValueInInput = '';
+    const wrapper = mount(Textarea, {
+      props: {
+        modelValue,
+        'onUpdate:modelValue': (value: string) => {
+          modelValue = value;
+        },
+        'onInput': () => {
+          modelValueInInput = modelValue;
+        },
+      },
+    });
+
+    await wrapper.find('textarea').setValue('textarea');
+
+    expect(modelValueInInput).toBe('textarea');
+  });
+
+  test('should update model before input event handlers run on compositionend', async () => {
+    let modelValue = '';
+    let modelValueInInput = '';
+    const wrapper = mount(Textarea, {
+      props: {
+        modelValue,
+        'onUpdate:modelValue': (value: string) => {
+          modelValue = value;
+        },
+        'onInput': () => {
+          modelValueInInput = modelValue;
+        },
+      },
+    });
+    const textarea = wrapper.find('textarea');
+
+    await textarea.trigger('compositionstart');
+    textarea.element.value = 'textarea';
+    await textarea.trigger('compositionend');
+
+    expect(modelValueInInput).toBe('textarea');
+  });
 });

--- a/packages/web-vue/components/textarea/textarea.vue
+++ b/packages/web-vue/components/textarea/textarea.vue
@@ -344,8 +344,8 @@ export default defineComponent({
           return;
         }
 
-        emit('input', value, e);
         updateValue(value);
+        emit('input', value, e);
         eventHandlers.value?.onInput?.(e);
       } else {
         isComposition.value = true;
@@ -367,8 +367,8 @@ export default defineComponent({
           return;
         }
 
-        emit('input', value, e);
         updateValue(value);
+        emit('input', value, e);
         eventHandlers.value?.onInput?.(e);
       } else {
         compositionValue.value = value;


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.

  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-vue/blob/main/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [ ] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

<!-- Explain what problem does the PR solve -->
Textarea emits the `input` event before updating its internal value and `v-model`. As a result, consumers reading the bound value inside an `@input` handler can observe the previous value.

<!-- Link to related open issues if applicable -->
https://github.com/arco-design/arco-design-vue/issues/3211

## Solution

<!-- Describe how the problem is fixed in detail -->
Update Textarea input handling so `updateValue(value)` runs before emitting `input`, matching the behavior of the Input component. This applies to both normal input and `compositionend`.


## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->
Added unit tests covering normal input and composition input ordering.

Ran:
```
./node_modules/.bin/vitest run components/textarea/__test__/index.test.ts
```
Result: 3 tests passed.

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| Textarea | 修复 Textarea 在 input 事件回调中读取到旧的 v-model 值的问题。 | Fix Textarea reading stale v-model value in input event handlers. | https://github.com/arco-design/arco-design-vue/issues/3211 |
<!-- If there are multiple types, you can add the `Type` column in the Changelog, the value of the column is the same as `Types of changes` -->

## Checklist:

- [x] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
