### PR TITLE
fix: 修复trigger组件props和interface定义不一致的问题

### DIFF
--- a/packages/web-vue/components/trigger/interface.ts
+++ b/packages/web-vue/components/trigger/interface.ts
@@ -27,11 +27,11 @@ export interface TriggerProps {
   popupStyle?: CSSProperties;
   animationName?: string;
   duration?:
-    | number
-    | {
-        enter: number;
-        leave: number;
-      };
+  | number
+  | {
+    enter: number;
+    leave: number;
+  };
   mouseEnterDelay?: number;
   mouseLeaveDelay?: number;
   focusDelay?: number;
@@ -40,5 +40,12 @@ export interface TriggerProps {
   autoFixPosition?: boolean;
   popupContainer?: string | HTMLElement;
   updateAtScroll?: boolean;
+  autoFitTransformOrigin?: boolean;
+  hideEmpty?: boolean;
+  opendClass?: string | string[] | Record<string, boolean>;
   autoFitPosition?: boolean;
+  renderToBody?: boolean;
+  preventFocus?: boolean;
+  scrollToClose?: boolean;
+  scrollToCloseDistance?: number;
 }


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
<!-- Only support choose one type, if there are multiple types, you can add the `Type` column in the Changelog. -->

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Component style change
- [x] Typescript definition change
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Test cases
- [ ] Continuous integration
- [ ] Breaking change
- [ ] Others

## Background and context

增加interface中的属性，保持和props中属性一致，解决ts中使用属性报错的问题
`error TS2353: Object literal may only specify known properties, and 'renderToBody' does not exist in type 'TriggerProps'.`

## Solution

## How is the change tested?

## Changelog

| Component | Changelog(CN) | Changelog(EN) | Related issues |
| --------- | ------------- | ------------- | -------------- |
| trigger | 补全 `TriggerProps` 缺失的类型定义 | Add missing properties to `TriggerProps` | |

## Checklist:

- [ ] Test suite passes (`npm run test`)
- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others
  should be submitted to `main` branch)

## Other information

<!-- Please describe what other information that should be taken care of. -->
